### PR TITLE
Add Dependabot configuration and enhance CI with release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+- package-ecosystem: "maven" # See documentation for possible values
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          cache: maven
 
       - name: Build with Maven
         run: ./mvnw

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,15 +14,22 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish'
+        description: 'The version to publish for Spring Cloud Hoxton+ and JDK 17+'
         required: true
-        default: '0.1.0-SNAPSHOT'
+        default: '${major}.${minor}.${patch}'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ inputs.revision }}
     steps:
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.revision }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
+          exit 1
+          fi
+
       - name: Checkout Source
         uses: actions/checkout@v5
 
@@ -37,7 +44,7 @@ jobs:
           cache: maven
 
       - name: Publish package
-        run: ./mvnw
+        run: mvn
           --batch-mode
           --update-snapshots
           --file pom.xml
@@ -51,3 +58,58 @@ jobs:
           SIGN_KEY_ID: ${{ secrets.OSS_SIGNING_KEY_ID_LONG }}
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
+
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Tag ${{ inputs.revision }} already exists, skipping."
+          else
+            git tag ${{ inputs.revision }}
+            git push origin ${{ inputs.revision }}
+          fi
+
+      - name: Create Release
+        run: |
+          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release v${{ inputs.revision }} already exists, skipping."
+          else
+            gh release create v${{ inputs.revision }} \
+              --title "v${{ inputs.revision }}" \
+              --generate-notes \
+              --latest
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Increment patch version
+        run: |
+          CURRENT="${{ inputs.revision }}"
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
+          sed -i "s|^\( *\)<revision>[^<]*</revision>|\1<revision>${NEXT_VERSION}</revision>|" pom.xml
+          echo "Bumped version from ${CURRENT} to ${NEXT_VERSION}"
+
+      - name: Commit and push next version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pom.xml
+          git diff --cached --quiet && echo "No changes to commit" || \
+            git commit -m "chore: bump version to next patch after publishing ${{ inputs.revision }}" && git push

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish for Spring Cloud Hoxton+ and JDK 17+'
+        description: 'The version to publish for Spring Cloud Hoxton+ and JDK 8+'
         required: true
         default: '${major}.${minor}.${patch}'
 

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,16 +1,3 @@
-# Copyright 2013-2023 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/microsphere-i18n-core/pom.xml
+++ b/microsphere-i18n-core/pom.xml
@@ -42,8 +42,20 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/AbstractResourceServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/AbstractResourceServiceMessageSource.java
@@ -18,7 +18,17 @@ import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 
 /**
- * Abstract Resource {@link ServiceMessageSource} Class
+ * Abstract Resource {@link ServiceMessageSource} Class that loads messages from resources
+ * keyed by {@link Locale}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Typically used through DefaultServiceMessageSource
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.init();
+ *   Map<String, Map<String, String>> messages = source.getLocalizedResourceMessages();
+ *   // messages keyed by resource name, e.g. "META-INF/i18n/test/i18n_messages_zh_CN.properties"
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -38,6 +48,11 @@ public abstract class AbstractResourceServiceMessageSource extends AbstractServi
 
     private volatile Map<String, Map<String, String>> localizedResourceMessages = emptyMap();
 
+    /**
+     * Constructs with the given source identifier.
+     *
+     * @param source the source identifier
+     */
     public AbstractResourceServiceMessageSource(String source) {
         super(source);
     }
@@ -114,6 +129,13 @@ public abstract class AbstractResourceServiceMessageSource extends AbstractServi
         messages.forEach((code, message) -> validateMessageCode(code, resourceName));
     }
 
+    /**
+     * Validates a message code for the given resource.
+     *
+     * @param code         the message code
+     * @param resourceName the resource name
+     * @throws IllegalStateException if the code is invalid
+     */
     protected void validateMessageCode(String code, String resourceName) {
         validateMessageCodePrefix(code, resourceName);
     }
@@ -125,11 +147,29 @@ public abstract class AbstractResourceServiceMessageSource extends AbstractServi
         }
     }
 
+    /**
+     * Gets the resource path for the specified {@link Locale}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   String resource = source.getResource(Locale.ENGLISH);
+     *   // e.g. "META-INF/i18n/test/i18n_messages_en.properties"
+     * }</pre>
+     *
+     * @param locale the target {@link Locale}
+     * @return the resource path
+     */
     public String getResource(Locale locale) {
         String resourceName = buildResourceName(locale);
         return getResource(resourceName);
     }
 
+    /**
+     * Builds the resource name for the given {@link Locale}.
+     *
+     * @param locale the target {@link Locale}
+     * @return the resource name, e.g. "i18n_messages_en.properties"
+     */
     protected String buildResourceName(Locale locale) {
         return DEFAULT_RESOURCE_NAME_PREFIX + locale + DEFAULT_RESOURCE_NAME_SUFFIX;
     }
@@ -139,6 +179,18 @@ public abstract class AbstractResourceServiceMessageSource extends AbstractServi
     @Nonnull
     protected abstract Map<String, String> loadMessages(String resource);
 
+    /**
+     * Gets the message map for the specified {@link Locale}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   Map<String, String> messages = source.getMessages(Locale.SIMPLIFIED_CHINESE);
+     *   // e.g. {"test.a": "测试-a", "test.hello": "您好,{}"}
+     * }</pre>
+     *
+     * @param locale the target {@link Locale}
+     * @return the message map, or {@code null} if no messages for the locale
+     */
     @Nullable
     public final Map<String, String> getMessages(Locale locale) {
         String resource = getResource(locale);
@@ -160,12 +212,36 @@ public abstract class AbstractResourceServiceMessageSource extends AbstractServi
         localizedResourceMessages.put(resource, messages);
     }
 
+    /**
+     * Logs a resolved message for debugging purposes.
+     *
+     * @param code            the original message code
+     * @param resolvedCode    the resolved message code
+     * @param locale          the requested locale
+     * @param resolvedLocale  the resolved locale
+     * @param args            the message arguments
+     * @param messagePattern  the raw message pattern
+     * @param message         the resolved message
+     */
     protected void logMessage(String code, String resolvedCode, Locale locale, Locale resolvedLocale, Object[] args,
                               String messagePattern, String message) {
         logger.trace("Source '{}' gets Message[code : '{}' , resolvedCode : '{}' , locale : '{}' , resolvedLocale : '{}', args : '{}' , pattern : '{}'] : '{}'",
                 source, code, resolvedCode, locale, resolvedLocale, arrayToString(args), messagePattern, message);
     }
 
+    /**
+     * Gets all localized resource messages as an unmodifiable map.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+     *   source.init();
+     *   Map<String, Map<String, String>> all = source.getLocalizedResourceMessages();
+     *   // 2 entries for zh_CN and en locales
+     * }</pre>
+     *
+     * @return unmodifiable map of resource name to message code-value pairs
+     */
     public Map<String, Map<String, String>> getLocalizedResourceMessages() {
         return unmodifiableMap(this.localizedResourceMessages);
     }

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/AbstractServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/AbstractServiceMessageSource.java
@@ -19,7 +19,17 @@ import static io.microsphere.util.Assert.assertNotNull;
 import static io.microsphere.util.StringUtils.isBlank;
 
 /**
- * Abstract {@link ServiceMessageSource}
+ * Abstract {@link ServiceMessageSource} providing base implementation for message resolution,
+ * locale management, and message code resolution.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Typically used via concrete subclass such as DefaultServiceMessageSource
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.setSupportedLocales(Arrays.asList(Locale.SIMPLIFIED_CHINESE, Locale.ENGLISH));
+ *   source.init();
+ *   String msg = source.getMessage("hello", Locale.ENGLISH, "World"); // "Hello,World"
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -36,6 +46,16 @@ public abstract class AbstractServiceMessageSource implements ServiceMessageSour
 
     private Locale defaultLocale;
 
+    /**
+     * Constructs an {@link AbstractServiceMessageSource} with the given source name.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+     * }</pre>
+     *
+     * @param source the source identifier, must not be null
+     */
     public AbstractServiceMessageSource(String source) {
         assertNotNull(source, () -> "'source' argument must not be null");
         this.source = source;
@@ -104,16 +124,46 @@ public abstract class AbstractServiceMessageSource implements ServiceMessageSour
         return this.source;
     }
 
+    /**
+     * Sets the default {@link Locale} for this message source.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   source.setDefaultLocale(Locale.SIMPLIFIED_CHINESE);
+     * }</pre>
+     *
+     * @param defaultLocale the default {@link Locale}
+     */
     public final void setDefaultLocale(Locale defaultLocale) {
         this.defaultLocale = defaultLocale;
-        this.logger.trace("Source '{}' sets the default Locale : '{}'", source, defaultLocale);
+        if (this.logger.isTraceEnabled()) {
+            this.logger.trace("Source '{}' sets the default Locale : '{}'", source, defaultLocale);
+        }
     }
 
+    /**
+     * Sets the supported {@link Locale locales} for this message source.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   source.setSupportedLocales(Arrays.asList(Locale.SIMPLIFIED_CHINESE, Locale.ENGLISH));
+     * }</pre>
+     *
+     * @param supportedLocales the collection of supported {@link Locale locales}
+     */
     public final void setSupportedLocales(Collection<Locale> supportedLocales) {
         this.supportedLocales = resolveHierarchicalLocales(supportedLocales);
-        this.logger.trace("Source '{}' sets the supported Locales : {}", source, supportedLocales);
+        if (this.logger.isTraceEnabled()) {
+            this.logger.trace("Source '{}' sets the supported Locales : {}", source, supportedLocales);
+        }
     }
 
+    /**
+     * Asserts that the given collection of supported locales is valid (non-empty, no null elements).
+     *
+     * @param supportedLocales the locales to validate
+     * @throws IllegalArgumentException if the collection is empty or contains null elements
+     */
     protected void assertSupportedLocales(Collection<Locale> supportedLocales) {
         assertNotEmpty(supportedLocales, () -> "The 'supportedLocales' must not be empty!");
         assertNoNullElements(supportedLocales, () -> "Any element of 'supportedLocales' must not be null!");
@@ -126,6 +176,19 @@ public abstract class AbstractServiceMessageSource implements ServiceMessageSour
     protected abstract String getInternalMessage(String code, String resolvedCode, Locale locale, Locale resolvedLocale,
                                                  Object... args);
 
+    /**
+     * Checks whether the given {@link Locale} is supported by this message source.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+     *   source.init();
+     *   boolean supported = source.supports(Locale.ENGLISH); // true
+     * }</pre>
+     *
+     * @param locale the {@link Locale} to check
+     * @return {@code true} if the locale is supported
+     */
     protected boolean supports(Locale locale) {
         Set<Locale> hierarchicalLocales = resolveHierarchicalLocales(locale);
         return hierarchicalLocales.contains(locale);
@@ -144,6 +207,12 @@ public abstract class AbstractServiceMessageSource implements ServiceMessageSour
         return hierarchicalLocales;
     }
 
+    /**
+     * Adds a {@link Locale} to the collection if not already present.
+     *
+     * @param locales the target collection
+     * @param locale  the {@link Locale} to add
+     */
     protected void addLocale(Collection<Locale> locales, Locale locale) {
         if (!locales.contains(locale)) {
             locales.add(locale);

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/CompositeServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/CompositeServiceMessageSource.java
@@ -23,6 +23,17 @@ import static java.util.Collections.unmodifiableSet;
 
 /**
  * The Composite {@link ServiceMessageSource} class, No thread safe.
+ * Delegates to a list of child {@link ServiceMessageSource} instances.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   CompositeServiceMessageSource composite = new CompositeServiceMessageSource(
+ *       Arrays.asList(EmptyServiceMessageSource.INSTANCE, source));
+ *   composite.init();
+ *   String msg = composite.getMessage("a"); // "测试-a" (from the DefaultServiceMessageSource)
+ *   composite.destroy();
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see AbstractServiceMessageSource
@@ -37,10 +48,29 @@ public class CompositeServiceMessageSource implements ReloadableResourceServiceM
 
     private List<? extends ServiceMessageSource> serviceMessageSources;
 
+    /**
+     * Constructs an empty {@link CompositeServiceMessageSource}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   CompositeServiceMessageSource composite = new CompositeServiceMessageSource();
+     * }</pre>
+     */
     public CompositeServiceMessageSource() {
         this.serviceMessageSources = emptyList();
     }
 
+    /**
+     * Constructs a {@link CompositeServiceMessageSource} with the given list of message sources.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   CompositeServiceMessageSource composite = new CompositeServiceMessageSource(
+     *       Arrays.asList(EmptyServiceMessageSource.INSTANCE, new DefaultServiceMessageSource("test")));
+     * }</pre>
+     *
+     * @param serviceMessageSources the list of {@link ServiceMessageSource} instances
+     */
     public CompositeServiceMessageSource(List<? extends ServiceMessageSource> serviceMessageSources) {
         setServiceMessageSources(serviceMessageSources);
     }
@@ -90,6 +120,11 @@ public class CompositeServiceMessageSource implements ReloadableResourceServiceM
                 unmodifiableSet(supportedLocales);
     }
 
+    /**
+     * Gets the default supported locales from the parent interface.
+     *
+     * @return default supported locales set
+     */
     public Set<Locale> getDefaultSupportedLocales() {
         return ReloadableResourceServiceMessageSource.super.getSupportedLocales();
     }
@@ -99,13 +134,25 @@ public class CompositeServiceMessageSource implements ReloadableResourceServiceM
         return ReloadableResourceServiceMessageSource.super.getSource();
     }
 
+    /**
+     * Sets and sorts the list of composited {@link ServiceMessageSource} instances.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   composite.setServiceMessageSources(Arrays.asList(source1, source2));
+     * }</pre>
+     *
+     * @param serviceMessageSources the list of {@link ServiceMessageSource} instances
+     */
     public void setServiceMessageSources(List<? extends ServiceMessageSource> serviceMessageSources) {
         List<ServiceMessageSource> newServiceMessageSources = new ArrayList<>(serviceMessageSources);
         sort(newServiceMessageSources);
 
         List<? extends ServiceMessageSource> oldServiceMessageSources = this.serviceMessageSources;
         this.serviceMessageSources = newServiceMessageSources;
-        logger.trace("The ServiceMessageSource original: '{}' , sorted : '{}'", serviceMessageSources, newServiceMessageSources);
+        if (logger.isTraceEnabled()) {
+            logger.trace("The ServiceMessageSource original: '{}' , sorted : '{}'", serviceMessageSources, newServiceMessageSources);
+        }
 
         if (oldServiceMessageSources != null) {
             oldServiceMessageSources.clear();
@@ -117,7 +164,9 @@ public class CompositeServiceMessageSource implements ReloadableResourceServiceM
         iterate(ReloadableResourceServiceMessageSource.class, reloadableResourceServiceMessageSource -> {
             if (reloadableResourceServiceMessageSource.canReload(changedResources)) {
                 reloadableResourceServiceMessageSource.reload(changedResources);
-                logger.trace("The '{}' reloaded the changed resources: {}", reloadableResourceServiceMessageSource, changedResources);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("The '{}' reloaded the changed resources: {}", reloadableResourceServiceMessageSource, changedResources);
+                }
             }
         });
     }

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/DefaultServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/DefaultServiceMessageSource.java
@@ -16,7 +16,17 @@ import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.ClassLoaderUtils.getDefaultClassLoader;
 
 /**
- * Default {@link ServiceMessageSource} Class
+ * Default {@link ServiceMessageSource} Class that loads i18n messages from classpath resources
+ * under {@code META-INF/i18n/{source}/}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.init();
+ *   assertEquals("测试-a", source.getMessage("a"));
+ *   assertEquals("Hello,World", source.getMessage("hello", Locale.ENGLISH, "World"));
+ *   source.destroy();
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -32,10 +42,21 @@ public class DefaultServiceMessageSource extends PropertiesResourceServiceMessag
     @Nonnull
     private final ClassLoader classLoader;
 
+    /**
+     * Constructs with the given source using the default class loader.
+     *
+     * @param source the source identifier
+     */
     public DefaultServiceMessageSource(String source) {
         this(source, null);
     }
 
+    /**
+     * Constructs with the given source and optional class loader.
+     *
+     * @param source      the source identifier
+     * @param classLoader the class loader to use, or {@code null} for the default
+     */
     public DefaultServiceMessageSource(String source, @Nullable ClassLoader classLoader) {
         super(source);
         this.classLoader = classLoader == null ? getDefaultClassLoader() : classLoader;

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/EmptyServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/EmptyServiceMessageSource.java
@@ -5,7 +5,17 @@ import io.microsphere.annotation.Nonnull;
 import java.util.Locale;
 
 /**
- * Empty {@link ServiceMessageSource}
+ * Empty {@link ServiceMessageSource} that always returns {@code null} for any message code.
+ * Used as a no-op fallback.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   ServiceMessageSource empty = EmptyServiceMessageSource.INSTANCE;
+ *   empty.init();
+ *   assertNull(empty.getMessage("any-code"));
+ *   assertEquals("Empty", empty.getSource());
+ *   empty.destroy();
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -14,6 +24,9 @@ public class EmptyServiceMessageSource implements ServiceMessageSource {
 
     public static final EmptyServiceMessageSource INSTANCE = new EmptyServiceMessageSource();
 
+    /**
+     * Default constructor.
+     */
     public EmptyServiceMessageSource() {
     }
 

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/PropertiesResourceServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/PropertiesResourceServiceMessageSource.java
@@ -17,13 +17,28 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
 /**
- * {@link Properties} Resource {@link ServiceMessageSource} Class
+ * {@link Properties} Resource {@link ServiceMessageSource} Class that loads messages
+ * from Java {@link Properties} files.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Typically used via DefaultServiceMessageSource
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.init();
+ *   Properties props = source.loadAllProperties(Locale.ENGLISH);
+ *   // props contains {"test.a": "test-a", "test.hello": "Hello,{}"}
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
 public abstract class PropertiesResourceServiceMessageSource extends AbstractResourceServiceMessageSource {
 
+    /**
+     * Constructs with the given source identifier.
+     *
+     * @param source the source identifier
+     */
     public PropertiesResourceServiceMessageSource(String source) {
         super(source);
     }
@@ -44,12 +59,31 @@ public abstract class PropertiesResourceServiceMessageSource extends AbstractRes
         return messages == null ? emptyMap() : unmodifiableMap(messages);
     }
 
+    /**
+     * Loads all properties for the specified {@link Locale}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   Properties props = source.loadAllProperties(Locale.ENGLISH);
+     * }</pre>
+     *
+     * @param locale the target {@link Locale}
+     * @return the loaded properties, or {@code null} if no resource found
+     * @throws IOException if an I/O error occurs
+     */
     @Nullable
     public Properties loadAllProperties(Locale locale) throws IOException {
         String resource = getResource(locale);
         return loadAllProperties(resource);
     }
 
+    /**
+     * Loads all properties from the specified resource.
+     *
+     * @param resource the resource path
+     * @return the loaded properties, or {@code null} if no resource found
+     * @throws IOException if an I/O error occurs
+     */
     @Nullable
     public Properties loadAllProperties(String resource) throws IOException {
         List<Reader> propertiesResources = loadAllPropertiesResources(resource);

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ReloadableResourceServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ReloadableResourceServiceMessageSource.java
@@ -1,7 +1,17 @@
 package io.microsphere.i18n;
 
 /**
- * Reloadable {@link ResourceServiceMessageSource}
+ * Reloadable {@link ResourceServiceMessageSource} that supports dynamic reloading
+ * of internationalized message resources at runtime.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.init();
+ *   if (source.canReload("META-INF/i18n/test/i18n_messages_en.properties")) {
+ *       source.reload("META-INF/i18n/test/i18n_messages_en.properties");
+ *   }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ResourceServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ResourceServiceMessageSource.java
@@ -9,7 +9,17 @@ import java.util.Set;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * Resource {@link ServiceMessageSource}
+ * Resource {@link ServiceMessageSource} that manages message resources initialization
+ * and tracks initialized resources.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.init();
+ *   Set<String> resources = source.getInitializedResources();
+ *   // e.g. ["META-INF/i18n/test/i18n_messages_zh_CN.properties",
+ *   //        "META-INF/i18n/test/i18n_messages_en.properties"]
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ServiceMessageException.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ServiceMessageException.java
@@ -27,7 +27,14 @@ import static io.microsphere.constants.SymbolConstants.SPACE;
 import static io.microsphere.util.ArrayUtils.arrayToString;
 
 /**
- * Service Message Exception
+ * Service Message Exception that resolves localized messages using {@link MessageUtils}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   ServiceMessageException e = new ServiceMessageException("{hello}", "World");
+ *   assertEquals("{hello}", e.getMessage());
+ *   assertEquals("您好,World", e.getLocalizedMessage()); // when Simplified Chinese is default
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0
@@ -38,6 +45,17 @@ public class ServiceMessageException extends RuntimeException {
 
     private final Object[] args;
 
+    /**
+     * Constructs a {@link ServiceMessageException} with the given message pattern and arguments.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   throw new ServiceMessageException("{hello}", "World");
+     * }</pre>
+     *
+     * @param message the message or message pattern (e.g. "{hello}")
+     * @param args    the arguments for the message pattern
+     */
     public ServiceMessageException(String message, Object... args) {
         this.message = message;
         this.args = args;

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ServiceMessageSource.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/ServiceMessageSource.java
@@ -13,7 +13,18 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Locale.getDefault;
 
 /**
- * Service internationalization message source
+ * Service internationalization message source.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   ServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   source.init();
+ *   // Get message in default locale (e.g. Simplified Chinese)
+ *   String msg = source.getMessage("a"); // "测试-a"
+ *   // Get message in a specific locale
+ *   String engMsg = source.getMessage("hello", Locale.ENGLISH, "World"); // "Hello,World"
+ *   source.destroy();
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -46,6 +57,21 @@ public interface ServiceMessageSource extends Prioritized {
     @Nullable
     String getMessage(String code, Locale locale, Object... args);
 
+    /**
+     * Getting international Messages using the runtime {@link Locale}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   ServiceMessageSource source = new DefaultServiceMessageSource("test");
+     *   source.init();
+     *   String msg = source.getMessage("a"); // "测试-a"
+     *   String hello = source.getMessage("hello", "World"); // "您好,World"
+     * }</pre>
+     *
+     * @param code message Code
+     * @param args the argument of message pattern
+     * @return {@code null} if message can't be found
+     */
     @Nullable
     default String getMessage(String code, Object... args) {
         return getMessage(code, getLocale(), args);

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/util/I18nUtils.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/util/I18nUtils.java
@@ -14,7 +14,23 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Internationalization Utilities class
+ * Internationalization Utilities class providing global access to the
+ * {@link ServiceMessageSource} and utility methods for service message source discovery.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Set the global ServiceMessageSource
+ *   DefaultServiceMessageSource source = new DefaultServiceMessageSource("test");
+ *   I18nUtils.setServiceMessageSource(source);
+ *   assertSame(source, I18nUtils.serviceMessageSource());
+ *
+ *   // Find all leaf ServiceMessageSources in a composite
+ *   CompositeServiceMessageSource composite = new CompositeServiceMessageSource(
+ *       Arrays.asList(EmptyServiceMessageSource.INSTANCE));
+ *   List<ServiceMessageSource> all = I18nUtils.findAllServiceMessageSources(composite);
+ *
+ *   I18nUtils.destroyServiceMessageSource();
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -25,29 +41,92 @@ public abstract class I18nUtils {
 
     private static volatile ServiceMessageSource serviceMessageSource;
 
+    /**
+     * Returns the global {@link ServiceMessageSource}, or {@link EmptyServiceMessageSource#INSTANCE}
+     * if not initialized.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   ServiceMessageSource source = I18nUtils.serviceMessageSource();
+     * }</pre>
+     *
+     * @return the current {@link ServiceMessageSource}, never null
+     */
     @Nonnull
     public static ServiceMessageSource serviceMessageSource() {
         if (serviceMessageSource == null) {
-            logger.warn("serviceMessageSource is not initialized, EmptyServiceMessageSource will be used");
+            if (logger.isWarnEnabled()) {
+                logger.warn("serviceMessageSource is not initialized, EmptyServiceMessageSource will be used");
+            }
             return INSTANCE;
         }
         return serviceMessageSource;
     }
 
+    /**
+     * Sets the global {@link ServiceMessageSource}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   I18nUtils.setServiceMessageSource(new DefaultServiceMessageSource("test"));
+     * }</pre>
+     *
+     * @param serviceMessageSource the {@link ServiceMessageSource} to set
+     */
     public static void setServiceMessageSource(ServiceMessageSource serviceMessageSource) {
         I18nUtils.serviceMessageSource = serviceMessageSource;
-        logger.trace("I18nUtils.serviceMessageSource is initialized : {}", serviceMessageSource);
+        if (logger.isTraceEnabled()) {
+            logger.trace("I18nUtils.serviceMessageSource is initialized : {}", serviceMessageSource);
+        }
     }
 
+    /**
+     * Destroys (nullifies) the global {@link ServiceMessageSource}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   I18nUtils.destroyServiceMessageSource();
+     * }</pre>
+     */
     public static void destroyServiceMessageSource() {
         serviceMessageSource = null;
-        logger.trace("serviceMessageSource is destroyed");
+        if (logger.isTraceEnabled()) {
+            logger.trace("serviceMessageSource is destroyed");
+        }
     }
 
+    /**
+     * Recursively finds all leaf {@link ServiceMessageSource} instances within a composite hierarchy.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   CompositeServiceMessageSource composite = new CompositeServiceMessageSource(
+     *       Arrays.asList(EmptyServiceMessageSource.INSTANCE));
+     *   List<ServiceMessageSource> all = I18nUtils.findAllServiceMessageSources(composite);
+     *   // returns [EmptyServiceMessageSource.INSTANCE]
+     * }</pre>
+     *
+     * @param serviceMessageSource the root {@link ServiceMessageSource}
+     * @return unmodifiable list of all leaf sources
+     */
     public static List<ServiceMessageSource> findAllServiceMessageSources(ServiceMessageSource serviceMessageSource) {
         return unmodifiableList(doFindAllServiceMessageSources(serviceMessageSource));
     }
 
+    /**
+     * Recursively finds all leaf {@link ServiceMessageSource} instances of a specific type.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   List<EmptyServiceMessageSource> sources =
+     *       I18nUtils.findAllServiceMessageSources(composite, EmptyServiceMessageSource.class);
+     * }</pre>
+     *
+     * @param serviceMessageSource     the root {@link ServiceMessageSource}
+     * @param serviceMessageSourceType the type to filter by
+     * @param <S>                      the target type
+     * @return unmodifiable list of matching sources
+     */
     public static <S extends ServiceMessageSource> List<S> findAllServiceMessageSources(ServiceMessageSource serviceMessageSource, Class<S> serviceMessageSourceType) {
         return unmodifiableList(doFindAllServiceMessageSources(serviceMessageSource)
                 .stream()

--- a/microsphere-i18n-core/src/main/java/io/microsphere/i18n/util/MessageUtils.java
+++ b/microsphere-i18n-core/src/main/java/io/microsphere/i18n/util/MessageUtils.java
@@ -14,7 +14,19 @@ import static io.microsphere.util.StringUtils.isNotBlank;
 import static io.microsphere.util.StringUtils.substringBetween;
 
 /**
- * Message Utilities class
+ * Message Utilities class for resolving internationalized messages from message patterns.
+ * Message patterns use the format {@code {messageCode}} where the code is resolved
+ * via the global {@link ServiceMessageSource}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Plain text returned as-is
+ *   assertEquals("a", MessageUtils.getLocalizedMessage("a"));
+ *   // Message code pattern resolved
+ *   assertEquals("测试-a", MessageUtils.getLocalizedMessage("{a}"));
+ *   // With locale and arguments
+ *   assertEquals("Hello,World", MessageUtils.getLocalizedMessage("{hello}", Locale.ENGLISH, "World"));
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -89,14 +101,18 @@ public abstract class MessageUtils {
         String messageCode = resolveMessageCode(messagePattern);
 
         if (messageCode == null) {
-            logger.trace("Message code not found in messagePattern'{}", messagePattern);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Message code not found in messagePattern'{}", messagePattern);
+            }
             return messagePattern;
         }
 
         ServiceMessageSource serviceMessageSource = serviceMessageSource();
         String localizedMessage = serviceMessageSource.getMessage(messageCode, locale, args);
         if (isNotBlank(localizedMessage)) {
-            logger.trace("Message Pattern ['{}'] corresponds to Locale ['{}'] with MessageSage:'{}'", messagePattern, locale, localizedMessage);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Message Pattern ['{}'] corresponds to Locale ['{}'] with MessageSage:'{}'", messagePattern, locale, localizedMessage);
+            }
         } else {
             int afterDotIndex = messageCode.indexOf(SOURCE_SEPARATOR) + 1;
             if (afterDotIndex > 0 && afterDotIndex < messageCode.length()) {
@@ -104,12 +120,27 @@ public abstract class MessageUtils {
             } else {
                 localizedMessage = messagePattern;
             }
-            logger.trace("No Message['{}'] found for Message Pattern ['{}'], returned: {}", messagePattern, locale, localizedMessage);
+            if (logger.isTraceEnabled()) {
+                logger.trace("No Message['{}'] found for Message Pattern ['{}'], returned: {}", messagePattern, locale, localizedMessage);
+            }
         }
 
         return localizedMessage;
     }
 
+    /**
+     * Resolves the message code from a message pattern by extracting the content between
+     * {@code {}} braces.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   String code = MessageUtils.resolveMessageCode("{hello}"); // returns "hello"
+     *   String noCode = MessageUtils.resolveMessageCode("plain"); // returns null
+     * }</pre>
+     *
+     * @param messagePattern the message pattern
+     * @return the resolved message code, or {@code null} if the pattern doesn't match
+     */
     public static String resolveMessageCode(String messagePattern) {
         String messageCode = substringBetween(messagePattern, MESSAGE_PATTERN_PREFIX, MESSAGE_PATTERN_SUFFIX);
         return messageCode;

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/AbstractI18nTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/AbstractI18nTest.java
@@ -16,9 +16,9 @@
  */
 package io.microsphere.i18n;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import static io.microsphere.i18n.util.I18nUtils.destroyServiceMessageSource;
 import static java.util.Locale.SIMPLIFIED_CHINESE;
@@ -36,19 +36,19 @@ public abstract class AbstractI18nTest {
 
     public static final String ERROR_SOURCE = "error";
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    static void beforeClass() {
         // Set the simplified Chinese as the default Locale
         setDefault(SIMPLIFIED_CHINESE);
     }
 
-    @Before
-    public void before() {
+    @BeforeEach
+    protected void before() {
         destroyServiceMessageSource();
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    protected void after() {
         destroyServiceMessageSource();
     }
 }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/AbstractResourceServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/AbstractResourceServiceMessageSourceTest.java
@@ -18,12 +18,12 @@
 package io.microsphere.i18n;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static io.microsphere.i18n.AbstractI18nTest.TEST_SOURCE;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * {@link AbstractResourceServiceMessageSource} Test
@@ -32,10 +32,10 @@ import static org.junit.Assert.assertThrows;
  * @see AbstractResourceServiceMessageSource
  * @since 1.0.0
  */
-public class AbstractResourceServiceMessageSourceTest {
+class AbstractResourceServiceMessageSourceTest {
 
     @Test
-    public void testInitialize() {
+    void testInitialize() {
         TestAbstractResourceServiceMessageSource serviceMessageSource = new TestAbstractResourceServiceMessageSource(TEST_SOURCE);
         assertThrows(IllegalArgumentException.class, serviceMessageSource::initialize);
     }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/CompositeServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/CompositeServiceMessageSourceTest.java
@@ -18,9 +18,10 @@
 package io.microsphere.i18n;
 
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
@@ -38,11 +39,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.getDefault;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link CompositeServiceMessageSource} Test
@@ -51,7 +52,8 @@ import static org.junit.Assert.assertTrue;
  * @see CompositeServiceMessageSource
  * @since 1.0.0
  */
-public class CompositeServiceMessageSourceTest {
+@SpringLoggingTest
+class CompositeServiceMessageSourceTest {
 
     private CompositeServiceMessageSource compositeServiceMessageSource;
 
@@ -67,8 +69,8 @@ public class CompositeServiceMessageSourceTest {
 
     private Set<Locale> locales = ofSet(getDefault(), ENGLISH);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         this.defaultServiceMessageSource = new DefaultServiceMessageSource(TEST_SOURCE);
         this.testReloadableResourceServiceMessageSource = new TestReloadableResourceServiceMessageSource();
         this.serviceMessageSources = ofList(INSTANCE, this.defaultServiceMessageSource, this.testReloadableResourceServiceMessageSource);
@@ -81,13 +83,13 @@ public class CompositeServiceMessageSourceTest {
         this.resources = ofList(this.defaultServiceMessageSource.getInitializedResources());
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         this.compositeServiceMessageSource.destroy();
     }
 
     @Test
-    public void testGetMessage() {
+    void testGetMessage() {
         assertGetMessage(TEST_SOURCE);
         assertGetMessage("a");
         assertGetMessage("hello", "world");
@@ -95,43 +97,43 @@ public class CompositeServiceMessageSourceTest {
     }
 
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         assertEquals(getDefault(), this.compositeServiceMessageSource.getLocale());
         assertEquals(getDefault(), this.emptyCompositeServiceMessageSource.getLocale());
     }
 
     @Test
-    public void testGetDefaultLocale() {
+    void testGetDefaultLocale() {
         assertEquals(getDefault(), this.compositeServiceMessageSource.getDefaultLocale());
         assertEquals(getDefault(), this.emptyCompositeServiceMessageSource.getDefaultLocale());
     }
 
     @Test
-    public void testGetSupportedLocales() {
+    void testGetSupportedLocales() {
         assertSupportedLocales(this.compositeServiceMessageSource::getSupportedLocales);
         assertSupportedLocales(this.emptyCompositeServiceMessageSource::getSupportedLocales);
     }
 
     @Test
-    public void testGetDefaultSupportedLocales() {
+    void testGetDefaultSupportedLocales() {
         assertSupportedLocales(this.compositeServiceMessageSource::getDefaultSupportedLocales);
         assertSupportedLocales(this.emptyCompositeServiceMessageSource::getDefaultSupportedLocales);
     }
 
     @Test
-    public void testGetSource() {
+    void testGetSource() {
         assertSame(COMMON_SOURCE, this.compositeServiceMessageSource.getSource());
         assertSame(COMMON_SOURCE, this.emptyCompositeServiceMessageSource.getSource());
     }
 
     @Test
-    public void testSetServiceMessageSources() {
+    void testSetServiceMessageSources() {
         this.compositeServiceMessageSource.setServiceMessageSources(emptyList());
         this.emptyCompositeServiceMessageSource.setServiceMessageSources(emptyList());
     }
 
     @Test
-    public void testReload() {
+    void testReload() {
         this.compositeServiceMessageSource.reload(this.resources);
         this.compositeServiceMessageSource.reload(this.resources.get(0));
         this.emptyCompositeServiceMessageSource.reload(this.resources);
@@ -142,7 +144,7 @@ public class CompositeServiceMessageSourceTest {
     }
 
     @Test
-    public void testCanReload() {
+    void testCanReload() {
         assertTrue(this.compositeServiceMessageSource.canReload(this.resources));
         assertTrue(this.compositeServiceMessageSource.canReload(this.resources.get(0)));
         assertTrue(this.emptyCompositeServiceMessageSource.canReload(this.resources));
@@ -150,19 +152,19 @@ public class CompositeServiceMessageSourceTest {
     }
 
     @Test
-    public void testInitializeResource() {
+    void testInitializeResource() {
         this.compositeServiceMessageSource.initializeResource(this.resources.get(0));
         this.emptyCompositeServiceMessageSource.initializeResource(this.resources.get(0));
     }
 
     @Test
-    public void testInitializeResources() {
+    void testInitializeResources() {
         this.compositeServiceMessageSource.initializeResources(this.resources);
         this.emptyCompositeServiceMessageSource.initializeResources(this.resources);
     }
 
     @Test
-    public void testGetInitializedResources() {
+    void testGetInitializedResources() {
         this.compositeServiceMessageSource.initializeResources(this.resources);
         this.emptyCompositeServiceMessageSource.initializeResources(this.resources);
         assertTrue(this.compositeServiceMessageSource.getInitializedResources().containsAll(this.defaultServiceMessageSource.getInitializedResources()));
@@ -170,19 +172,19 @@ public class CompositeServiceMessageSourceTest {
     }
 
     @Test
-    public void testGetEncoding() {
+    void testGetEncoding() {
         assertEquals(UTF_8, this.compositeServiceMessageSource.getEncoding());
         assertEquals(UTF_8, this.emptyCompositeServiceMessageSource.getEncoding());
     }
 
     @Test
-    public void testGetServiceMessageSources() {
+    void testGetServiceMessageSources() {
         assertEquals(ofList(INSTANCE, this.defaultServiceMessageSource, this.testReloadableResourceServiceMessageSource), this.compositeServiceMessageSource.getServiceMessageSources());
         assertEquals(emptyList(), this.emptyCompositeServiceMessageSource.getServiceMessageSources());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         assertNotNull(this.compositeServiceMessageSource.toString());
         assertNotNull(this.emptyCompositeServiceMessageSource.toString());
     }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/DefaultServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/DefaultServiceMessageSourceTest.java
@@ -1,6 +1,6 @@
 package io.microsphere.i18n;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -11,13 +11,13 @@ import static io.microsphere.util.ClassLoaderUtils.getDefaultClassLoader;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.FRANCE;
 import static java.util.Locale.getDefault;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link DefaultServiceMessageSource} Test
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMessageSourceTest {
+class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMessageSourceTest {
 
     @Override
     protected DefaultServiceMessageSource createServiceMessageSource() {
@@ -34,7 +34,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
 
     @Test
     @Override
-    public void testGetMessage() {
+    void testGetMessage() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
 
         assertEquals("测试-a", serviceMessageSource.getMessage("a"));
@@ -42,7 +42,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
     }
 
     @Test
-    public void testResources() {
+    void testResources() {
         ResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         serviceMessageSource.initializeResource(ERROR_SOURCE);
         assertFalse(serviceMessageSource.getInitializedResources().isEmpty());
@@ -50,13 +50,13 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
 
     @Test
     @Override
-    public void testGetSource() {
+    void testGetSource() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
         assertEquals(TEST_SOURCE, serviceMessageSource.getSource());
     }
 
     @Test
-    public void testValidateMessageCode() {
+    void testValidateMessageCode() {
         assertThrows(IllegalStateException.class, () -> {
             DefaultServiceMessageSource serviceMessageSource = new DefaultServiceMessageSource(ERROR_SOURCE);
             serviceMessageSource.initialize();
@@ -64,7 +64,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
     }
 
     @Test
-    public void testGetInternalLocale() {
+    void testGetInternalLocale() {
         DefaultServiceMessageSource serviceMessageSource = new DefaultServiceMessageSource(TEST_SOURCE, getDefaultClassLoader()) {
 
             @Override
@@ -76,7 +76,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
     }
 
     @Test
-    public void testSupports() {
+    void testSupports() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
 
         assertTrue(serviceMessageSource.supports(getDefault()));
@@ -84,7 +84,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
     }
 
     @Test
-    public void testResolveMessageCode() {
+    void testResolveMessageCode() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
 
         String code = "test.code";
@@ -93,7 +93,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
     }
 
     @Test
-    public void testGetLocalizedResourceMessages() {
+    void testGetLocalizedResourceMessages() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
 
         Map<String, Map<String, String>> localizedResourceMessages = serviceMessageSource.getLocalizedResourceMessages();
@@ -101,7 +101,7 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
     }
 
     @Test
-    public void testLoadAllProperties() throws IOException {
+    void testLoadAllProperties() throws IOException {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
         for (Locale locale : serviceMessageSource.getSupportedLocales()) {
             assertNotNull(serviceMessageSource.loadAllProperties(locale));
@@ -112,28 +112,28 @@ public class DefaultServiceMessageSourceTest extends ReloadableResourceServiceMe
 
     @Test
     @Override
-    public void testCanReload() {
+    void testCanReload() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
         assertFalse(serviceMessageSource.canReload(TEST_SOURCE));
     }
 
     @Test
     @Override
-    public void testCanReloadWithIterable() {
+    void testCanReloadWithIterable() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
         assertFalse(serviceMessageSource.canReload(ofSet(TEST_SOURCE)));
     }
 
     @Test
     @Override
-    public void testReload() {
+    void testReload() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
         serviceMessageSource.reload(TEST_SOURCE);
     }
 
     @Test
     @Override
-    public void testReloadWithIterable() {
+    void testReloadWithIterable() {
         DefaultServiceMessageSource serviceMessageSource = getServiceMessageSource();
         serviceMessageSource.reload(ofSet(TEST_SOURCE));
     }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/EmptyServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/EmptyServiceMessageSourceTest.java
@@ -1,15 +1,15 @@
 package io.microsphere.i18n;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.i18n.EmptyServiceMessageSource.INSTANCE;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.getDefault;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * {@link EmptyServiceMessageSource} Test
@@ -18,46 +18,46 @@ import static org.junit.Assert.assertNull;
  * @see EmptyServiceMessageSource
  * @since 1.0.0
  */
-public class EmptyServiceMessageSourceTest extends AbstractI18nTest {
+class EmptyServiceMessageSourceTest extends AbstractI18nTest {
 
     private EmptyServiceMessageSource serviceMessageSource = INSTANCE;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    protected void before() {
         super.before();
         serviceMessageSource.init();
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    protected void after() {
         super.after();
         serviceMessageSource.destroy();
     }
 
     @Test
-    public void testGetMessage() {
+    void testGetMessage() {
         assertNull(serviceMessageSource.getMessage(TEST_SOURCE));
         assertNull(serviceMessageSource.getMessage(TEST_SOURCE, "a"));
         assertNull(serviceMessageSource.getMessage(TEST_SOURCE, ENGLISH, "a"));
     }
 
     @Test
-    public void testGetSource() {
+    void testGetSource() {
         assertEquals("Empty", serviceMessageSource.getSource());
     }
 
     @Test
-    public void testGetDefaultLocale() {
+    void testGetDefaultLocale() {
         assertEquals(getDefault(), serviceMessageSource.getDefaultLocale());
     }
 
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         assertEquals(getDefault(), serviceMessageSource.getLocale());
     }
 
     @Test
-    public void testGetSupportedLocales() {
+    void testGetSupportedLocales() {
         assertEquals(ofSet(getDefault(), ENGLISH), serviceMessageSource.getSupportedLocales());
     }
 }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/PropertiesResourceServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/PropertiesResourceServiceMessageSourceTest.java
@@ -18,11 +18,17 @@
 package io.microsphere.i18n;
 
 
-import org.junit.Before;
-import org.junit.Test;
+import io.microsphere.logging.test.jupiter.LoggingLevelsTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static io.microsphere.collection.Lists.ofList;
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.i18n.AbstractI18nTest.TEST_SOURCE;
-import static org.junit.Assert.assertThrows;
+import static java.util.Locale.CHINESE;
+import static java.util.Locale.FRANCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * {@link PropertiesResourceServiceMessageSource} Test
@@ -31,17 +37,31 @@ import static org.junit.Assert.assertThrows;
  * @see PropertiesResourceServiceMessageSource
  * @since 1.0.0
  */
-public class PropertiesResourceServiceMessageSourceTest {
+class PropertiesResourceServiceMessageSourceTest {
 
     private PropertiesResourceServiceMessageSource propertiesResourceServiceMessageSource;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         this.propertiesResourceServiceMessageSource = new TestPropertiesResourceServiceMessageSource(TEST_SOURCE);
     }
 
     @Test
-    public void testLoadMessages() {
+    void testLoadMessages() {
         assertThrows(RuntimeException.class, () -> this.propertiesResourceServiceMessageSource.loadMessages("test"));
+    }
+
+    @Test
+    @LoggingLevelsTest(levels = "ERROR")
+    void testSetDefaultLocale() {
+        this.propertiesResourceServiceMessageSource.setDefaultLocale(FRANCE);
+        assertEquals(FRANCE, this.propertiesResourceServiceMessageSource.getDefaultLocale());
+    }
+
+    @Test
+    @LoggingLevelsTest(levels = "ERROR")
+    void testSetSupportedLocales() {
+        this.propertiesResourceServiceMessageSource.setSupportedLocales(ofList(CHINESE));
+        assertEquals(ofSet(CHINESE), this.propertiesResourceServiceMessageSource.getSupportedLocales());
     }
 }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ReloadableResourceServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ReloadableResourceServiceMessageSourceTest.java
@@ -17,13 +17,13 @@
 
 package io.microsphere.i18n;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.collection.SetUtils.ofSet;
 import static io.microsphere.collection.Sets.ofSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link ReloadableResourceServiceMessageSource} Test
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  * @see TestReloadableResourceServiceMessageSource
  * @since 1.0.0
  */
-public class ReloadableResourceServiceMessageSourceTest extends ResourceServiceMessageSourceTest {
+class ReloadableResourceServiceMessageSourceTest extends ResourceServiceMessageSourceTest {
 
     @Override
     protected ReloadableResourceServiceMessageSource createServiceMessageSource() {
@@ -41,14 +41,14 @@ public class ReloadableResourceServiceMessageSourceTest extends ResourceServiceM
     }
 
     @Test
-    public void testReload() {
+    void testReload() {
         ReloadableResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         serviceMessageSource.reload(TEST_SOURCE);
         assertEquals(ofSet(TEST_SOURCE), serviceMessageSource.getInitializedResources());
     }
 
     @Test
-    public void testReloadWithIterable() {
+    void testReloadWithIterable() {
         ReloadableResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         Iterable<String> resources = ofSet(TEST_SOURCE);
         serviceMessageSource.reload(resources);
@@ -56,7 +56,7 @@ public class ReloadableResourceServiceMessageSourceTest extends ResourceServiceM
     }
 
     @Test
-    public void testCanReload() {
+    void testCanReload() {
         ReloadableResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         assertFalse(serviceMessageSource.canReload(TEST_SOURCE));
         serviceMessageSource.reload(TEST_SOURCE);
@@ -64,7 +64,7 @@ public class ReloadableResourceServiceMessageSourceTest extends ResourceServiceM
     }
 
     @Test
-    public void testCanReloadWithIterable() {
+    void testCanReloadWithIterable() {
         ReloadableResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         Iterable<String> resources = ofSet(TEST_SOURCE);
         assertFalse(serviceMessageSource.canReload(resources));

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ResourceServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ResourceServiceMessageSourceTest.java
@@ -18,11 +18,11 @@
 package io.microsphere.i18n;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.collection.Sets.ofSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link ResourceServiceMessageSource} Test
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
  * @see ResourceServiceMessageSource
  * @since 1.0.0
  */
-public class ResourceServiceMessageSourceTest extends ServiceMessageSourceTest {
+class ResourceServiceMessageSourceTest extends ServiceMessageSourceTest {
 
     @Override
     protected ResourceServiceMessageSource createServiceMessageSource() {
@@ -39,7 +39,7 @@ public class ResourceServiceMessageSourceTest extends ServiceMessageSourceTest {
     }
 
     @Test
-    public void testResources() {
+    void testResources() {
         ResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         Iterable<String> resources = ofSet(TEST_SOURCE);
         serviceMessageSource.initializeResource(TEST_SOURCE);
@@ -47,7 +47,7 @@ public class ResourceServiceMessageSourceTest extends ServiceMessageSourceTest {
     }
 
     @Test
-    public void testGetEncoding() {
+    void testGetEncoding() {
         ResourceServiceMessageSource serviceMessageSource = getServiceMessageSource();
         assertEquals(UTF_8, serviceMessageSource.getEncoding());
     }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ServiceMessageExceptionTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ServiceMessageExceptionTest.java
@@ -16,9 +16,9 @@
  */
 package io.microsphere.i18n;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.i18n.AbstractI18nTest.TEST_SOURCE;
@@ -27,8 +27,8 @@ import static io.microsphere.i18n.util.I18nUtils.setServiceMessageSource;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.ArrayUtils.arrayToString;
 import static java.util.Locale.SIMPLIFIED_CHINESE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link ServiceMessageException} Test
@@ -36,10 +36,10 @@ import static org.junit.Assert.assertTrue;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0
  */
-public class ServiceMessageExceptionTest {
+class ServiceMessageExceptionTest {
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         DefaultServiceMessageSource serviceMessageSource = new DefaultServiceMessageSource(TEST_SOURCE);
         serviceMessageSource.setDefaultLocale(SIMPLIFIED_CHINESE);
         serviceMessageSource.setSupportedLocales(ofList(SIMPLIFIED_CHINESE));
@@ -47,13 +47,13 @@ public class ServiceMessageExceptionTest {
         setServiceMessageSource(serviceMessageSource);
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         destroyServiceMessageSource();
     }
 
     @Test
-    public void test() {
+    void test() {
         assertServiceMessageException("测试-a", "{a}");
         assertServiceMessageException("您好,World", "{hello}", "World");
     }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ServiceMessageSourceTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/ServiceMessageSourceTest.java
@@ -18,18 +18,18 @@
 package io.microsphere.i18n;
 
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.i18n.ServiceMessageSource.COMMON_SOURCE;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.getDefault;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * {@link ServiceMessageSource} Test
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertSame;
  * @see ServiceMessageSource
  * @since 1.0.0
  */
-public class ServiceMessageSourceTest extends AbstractI18nTest {
+class ServiceMessageSourceTest extends AbstractI18nTest {
 
     private ServiceMessageSource serviceMessageSource;
 
@@ -50,50 +50,50 @@ public class ServiceMessageSourceTest extends AbstractI18nTest {
         return (T) serviceMessageSource;
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         this.serviceMessageSource = createServiceMessageSource();
         this.serviceMessageSource.init();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         this.serviceMessageSource.destroy();
     }
 
     @Test
-    public void testConstants() {
+    void testConstants() {
         assertSame("common", COMMON_SOURCE);
     }
 
     @Test
-    public void testGetMessage() {
+    void testGetMessage() {
         assertNull(this.serviceMessageSource.getMessage("code"));
         assertNull(this.serviceMessageSource.getMessage("code", ENGLISH));
     }
 
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         assertSame(getDefault(), this.serviceMessageSource.getLocale());
     }
 
     @Test
-    public void testGetDefaultLocale() {
+    void testGetDefaultLocale() {
         assertSame(getDefault(), this.serviceMessageSource.getDefaultLocale());
     }
 
     @Test
-    public void testGetSupportedLocales() {
+    void testGetSupportedLocales() {
         assertEquals(ofSet(getDefault(), ENGLISH), this.serviceMessageSource.getSupportedLocales());
     }
 
     @Test
-    public void testGetSource() {
+    void testGetSource() {
         assertEquals(COMMON_SOURCE, this.serviceMessageSource.getSource());
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         assertNotNull(this.serviceMessageSource.toString());
     }
 }

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/util/I18nUtilsTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/util/I18nUtilsTest.java
@@ -5,7 +5,8 @@ import io.microsphere.i18n.CompositeServiceMessageSource;
 import io.microsphere.i18n.DefaultServiceMessageSource;
 import io.microsphere.i18n.EmptyServiceMessageSource;
 import io.microsphere.i18n.ServiceMessageSource;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -14,8 +15,8 @@ import static io.microsphere.i18n.EmptyServiceMessageSource.INSTANCE;
 import static io.microsphere.i18n.util.I18nUtils.findAllServiceMessageSources;
 import static io.microsphere.i18n.util.I18nUtils.serviceMessageSource;
 import static io.microsphere.i18n.util.I18nUtils.setServiceMessageSource;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * {@link I18nUtils} Test
@@ -23,10 +24,11 @@ import static org.junit.Assert.assertSame;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public class I18nUtilsTest extends AbstractI18nTest {
+@SpringLoggingTest
+class I18nUtilsTest extends AbstractI18nTest {
 
     @Test
-    public void test() {
+    void test() {
         assertSame(INSTANCE, serviceMessageSource());
 
         DefaultServiceMessageSource defaultServiceMessageSource = new DefaultServiceMessageSource(TEST_SOURCE);
@@ -36,7 +38,7 @@ public class I18nUtilsTest extends AbstractI18nTest {
     }
 
     @Test
-    public void testFindAllServiceMessageSources() {
+    void testFindAllServiceMessageSources() {
         List<ServiceMessageSource> serviceMessageSources = ofList(INSTANCE);
         CompositeServiceMessageSource compositeServiceMessageSource = new CompositeServiceMessageSource(ofList(INSTANCE));
         assertEquals(serviceMessageSources, findAllServiceMessageSources(compositeServiceMessageSource));

--- a/microsphere-i18n-core/src/test/java/io/microsphere/i18n/util/MessageUtilsTest.java
+++ b/microsphere-i18n-core/src/test/java/io/microsphere/i18n/util/MessageUtilsTest.java
@@ -2,8 +2,9 @@ package io.microsphere.i18n.util;
 
 import io.microsphere.i18n.AbstractI18nTest;
 import io.microsphere.i18n.DefaultServiceMessageSource;
-import org.junit.Before;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.i18n.util.I18nUtils.setServiceMessageSource;
 import static io.microsphere.i18n.util.MessageUtils.MESSAGE_PATTERN_PREFIX;
@@ -11,7 +12,7 @@ import static io.microsphere.i18n.util.MessageUtils.MESSAGE_PATTERN_SUFFIX;
 import static io.microsphere.i18n.util.MessageUtils.SOURCE_SEPARATOR;
 import static io.microsphere.i18n.util.MessageUtils.getLocalizedMessage;
 import static java.util.Locale.ENGLISH;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link MessageUtils} Test
@@ -19,10 +20,11 @@ import static org.junit.Assert.assertEquals;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public class MessageUtilsTest extends AbstractI18nTest {
+@SpringLoggingTest
+class MessageUtilsTest extends AbstractI18nTest {
 
-    @Before
-    public void before() {
+    @BeforeEach
+    protected void before() {
         super.before();
         DefaultServiceMessageSource serviceMessageSource = new DefaultServiceMessageSource(TEST_SOURCE);
         serviceMessageSource.init();
@@ -30,14 +32,14 @@ public class MessageUtilsTest extends AbstractI18nTest {
     }
 
     @Test
-    public void testConstants() {
+    void testConstants() {
         assertEquals("{", MESSAGE_PATTERN_PREFIX);
         assertEquals("}", MESSAGE_PATTERN_SUFFIX);
         assertEquals(".", SOURCE_SEPARATOR);
     }
 
     @Test
-    public void testGetLocalizedMessage() {
+    void testGetLocalizedMessage() {
         // Testing Simplified Chinese
         // null
         assertEquals(null, getLocalizedMessage(null));

--- a/microsphere-i18n-openfeign/pom.xml
+++ b/microsphere-i18n-openfeign/pom.xml
@@ -57,8 +57,26 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-i18n-openfeign/src/main/java/io/microsphere/i18n/feign/AcceptLanguageHeaderRequestInterceptor.java
+++ b/microsphere-i18n-openfeign/src/main/java/io/microsphere/i18n/feign/AcceptLanguageHeaderRequestInterceptor.java
@@ -15,7 +15,19 @@ import static org.springframework.util.StringUtils.hasText;
 import static org.springframework.web.context.request.RequestContextHolder.getRequestAttributes;
 
 /**
- * HTTP Header "Accept-Language" {@link RequestInterceptor}
+ * HTTP Header "Accept-Language" {@link RequestInterceptor} that propagates the
+ * {@code Accept-Language} header from the current HTTP request to Feign client requests.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Register as a Feign RequestInterceptor bean
+ *   @Bean
+ *   public AcceptLanguageHeaderRequestInterceptor acceptLanguageInterceptor() {
+ *       return new AcceptLanguageHeaderRequestInterceptor();
+ *   }
+ *   // The interceptor automatically copies the Accept-Language header
+ *   // from the incoming request to outgoing Feign requests
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see AcceptHeaderLocaleResolver
@@ -31,7 +43,9 @@ public class AcceptLanguageHeaderRequestInterceptor implements RequestIntercepto
     public void apply(RequestTemplate template) {
         RequestAttributes requestAttributes = getRequestAttributes();
         if (!(requestAttributes instanceof ServletRequestAttributes)) {
-            logger.trace("Feign calls in non-Spring WebMVC scenarios, ignoring setting request headers: '{}'", HEADER_NAME);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Feign calls in non-Spring WebMVC scenarios, ignoring setting request headers: '{}'", HEADER_NAME);
+            }
             return;
         }
 
@@ -43,9 +57,13 @@ public class AcceptLanguageHeaderRequestInterceptor implements RequestIntercepto
 
         if (hasText(acceptLanguage)) {
             template.header(HEADER_NAME, acceptLanguage);
-            logger.trace("Feign has set HTTP request header [name : '{}' , value : '{}']", HEADER_NAME, acceptLanguage);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Feign has set HTTP request header [name : '{}' , value : '{}']", HEADER_NAME, acceptLanguage);
+            }
         } else {
-            logger.trace("Feign could not set HTTP request header [name : '{}'] because the requester did not pass: '{}'", HEADER_NAME, acceptLanguage);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Feign could not set HTTP request header [name : '{}'] because the requester did not pass: '{}'", HEADER_NAME, acceptLanguage);
+            }
         }
     }
 }

--- a/microsphere-i18n-openfeign/src/test/java/io/microsphere/i18n/feign/AcceptLanguageHeaderRequestInterceptorTest.java
+++ b/microsphere-i18n-openfeign/src/test/java/io/microsphere/i18n/feign/AcceptLanguageHeaderRequestInterceptorTest.java
@@ -1,16 +1,17 @@
 package io.microsphere.i18n.feign;
 
 import feign.RequestTemplate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.i18n.feign.AcceptLanguageHeaderRequestInterceptor.HEADER_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes;
 import static org.springframework.web.context.request.RequestContextHolder.setRequestAttributes;
 
@@ -20,7 +21,8 @@ import static org.springframework.web.context.request.RequestContextHolder.setRe
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-public class AcceptLanguageHeaderRequestInterceptorTest {
+@SpringLoggingTest
+class AcceptLanguageHeaderRequestInterceptorTest {
 
     private AcceptLanguageHeaderRequestInterceptor requestInterceptor;
 
@@ -28,21 +30,21 @@ public class AcceptLanguageHeaderRequestInterceptorTest {
 
     private MockHttpServletRequest request;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         this.request = new MockHttpServletRequest();
         this.requestInterceptor = new AcceptLanguageHeaderRequestInterceptor();
         this.requestTemplate = new RequestTemplate();
         setRequestAttributes(new ServletRequestAttributes(request));
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         resetRequestAttributes();
     }
 
     @Test
-    public void testApply() {
+    void testApply() {
         this.request.addHeader(HEADER_NAME, "en");
         assertTrue(requestTemplate.headers().isEmpty());
         requestInterceptor.apply(requestTemplate);
@@ -50,14 +52,14 @@ public class AcceptLanguageHeaderRequestInterceptorTest {
     }
 
     @Test
-    public void testApplyWithoutAcceptLanguageHeader() {
+    void testApplyWithoutAcceptLanguageHeader() {
         assertTrue(requestTemplate.headers().isEmpty());
         requestInterceptor.apply(requestTemplate);
         assertTrue(requestTemplate.headers().isEmpty());
     }
 
     @Test
-    public void testApplyNoWebMvc() {
+    void testApplyNoWebMvc() {
         resetRequestAttributes();
         assertTrue(requestTemplate.headers().isEmpty());
         requestInterceptor.apply(new RequestTemplate());

--- a/microsphere-i18n-parent/pom.xml
+++ b/microsphere-i18n-parent/pom.xml
@@ -20,13 +20,22 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.5</microsphere-spring-cloud.version>
-        <testcontainers.version>2.0.1</testcontainers.version>
+        <microsphere-spring-cloud.version>0.1.6</microsphere-spring-cloud.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
+        <!-- Testing -->
+        <junit-jupiter.version>5.14.3</junit-jupiter.version>
     </properties>
 
     <dependencyManagement>
-
         <dependencies>
+            <!-- JUnit BOM -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <!-- Testcontainers Dependencies -->
             <dependency>
@@ -129,5 +138,4 @@
         </profile>
 
     </profiles>
-
 </project>

--- a/microsphere-i18n-spring-boot/pom.xml
+++ b/microsphere-i18n-spring-boot/pom.xml
@@ -70,12 +70,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -106,14 +100,20 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/actuate/I18nEndpoint.java
+++ b/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/actuate/I18nEndpoint.java
@@ -55,7 +55,16 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 
 /**
- * I18n Spring Boot Actuator Endpoint
+ * I18n Spring Boot Actuator Endpoint providing read and write operations
+ * for internationalized messages.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Access via Spring Boot Actuator:
+ *   // GET /actuator/i18n              - List all messages
+ *   // GET /actuator/i18n/{code}       - Get message by code
+ *   // POST /actuator/i18n             - Add a new message
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0
@@ -260,7 +269,9 @@ public class I18nEndpoint {
     public Map<String, Object> addMessage(String source, Locale locale, String code, String message) throws IOException {
         PropertySourcesServiceMessageSource serviceMessageSource = getPropertySourcesServiceMessageSource(source);
         if (serviceMessageSource == null) {
-            logger.trace("No PropertySourcesServiceMessageSource Bean was found by the source : '{}'", source);
+            if (logger.isTraceEnabled()) {
+                logger.trace("No PropertySourcesServiceMessageSource Bean was found by the source : '{}'", source);
+            }
             return emptyMap();
         }
         Properties properties = loadProperties(serviceMessageSource, locale);

--- a/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/actuate/autoconfigure/I18nEndpointAutoConfiguration.java
+++ b/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/actuate/autoconfigure/I18nEndpointAutoConfiguration.java
@@ -26,7 +26,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 
 /**
- * I18n Spring Boot Actuator Endpoint Auto-Configuration
+ * I18n Spring Boot Actuator Endpoint Auto-Configuration that registers the
+ * {@link I18nEndpoint} for monitoring and managing i18n messages.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Auto-configured when Spring Boot Actuator and i18n are both enabled
+ *   // Access via: GET /actuator/i18n
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see I18nEndpoint
@@ -41,6 +48,11 @@ public class I18nEndpointAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    /**
+     * Creates the {@link I18nEndpoint} bean.
+     *
+     * @return a new {@link I18nEndpoint} instance
+     */
     public I18nEndpoint i18nEndpoint() {
         return new I18nEndpoint();
     }

--- a/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/autoconfigure/I18nAutoConfiguration.java
+++ b/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/autoconfigure/I18nAutoConfiguration.java
@@ -24,7 +24,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
 /**
- * I18n Auto-Configuration
+ * I18n Auto-Configuration for Spring Boot that automatically enables i18n support
+ * and registers an application-specific {@link ServiceMessageSourceFactoryBean}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Auto-configured when microsphere.i18n.enabled=true (default)
+ *   // In application.properties:
+ *   // spring.application.name=myapp
+ *   // microsphere.i18n.enabled=true
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0
@@ -33,6 +42,12 @@ import org.springframework.context.annotation.Bean;
 @EnableI18n
 public class I18nAutoConfiguration {
 
+    /**
+     * Creates a {@link ServiceMessageSourceFactoryBean} for the application-specific i18n source.
+     *
+     * @param applicationName the Spring application name
+     * @return the factory bean
+     */
     @Bean
     @ConditionalOnProperty(name = "spring.application.name")
     public ServiceMessageSourceFactoryBean applicationServiceMessageSource(

--- a/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/condition/ConditionalOnI18nEnabled.java
+++ b/microsphere-i18n-spring-boot/src/main/java/io/microsphere/i18n/spring/boot/condition/ConditionalOnI18nEnabled.java
@@ -13,7 +13,18 @@ import java.lang.annotation.Target;
 import static io.microsphere.i18n.spring.constants.I18nConstants.ENABLED_PROPERTY_NAME;
 
 /**
- * {@link Conditional @Conditional} that checks whether the I18n enabled
+ * {@link Conditional @Conditional} that checks whether I18n is enabled.
+ * Combines class presence checks and property condition ({@code microsphere.i18n.enabled}).
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   @ConditionalOnI18nEnabled
+ *   @Configuration
+ *   public class MyI18nConfig {
+ *       // Only activated when i18n core and spring modules are on classpath
+ *       // and microsphere.i18n.enabled is true (default)
+ *   }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0

--- a/microsphere-i18n-spring-boot/src/test/java/io/microsphere/i18n/spring/boot/actuate/I18nEndpointTest.java
+++ b/microsphere-i18n-spring-boot/src/test/java/io/microsphere/i18n/spring/boot/actuate/I18nEndpointTest.java
@@ -4,6 +4,7 @@ import com.jayway.jsonpath.DocumentContext;
 import io.microsphere.i18n.ServiceMessageSource;
 import io.microsphere.i18n.spring.boot.actuate.autoconfigure.I18nEndpointAutoConfiguration;
 import io.microsphere.i18n.spring.boot.autoconfigure.I18nAutoConfiguration;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  * @see I18nEndpoint
  * @since 1.0.0
  */
+@SpringLoggingTest
 @SpringBootTest(
         classes = I18nEndpointTest.EndpointConfiguration.class,
         properties = {

--- a/microsphere-i18n-spring-cloud-server/pom.xml
+++ b/microsphere-i18n-spring-cloud-server/pom.xml
@@ -76,12 +76,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/microsphere-i18n-spring-cloud-server/src/main/java/io/microsphere/i18n/spring/cloud/server/annotation/EnableI18nServer.java
+++ b/microsphere-i18n-spring-cloud-server/src/main/java/io/microsphere/i18n/spring/cloud/server/annotation/EnableI18nServer.java
@@ -27,7 +27,19 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Enable I18n Server
+ * Enable I18n Server that exposes a REST endpoint for serving
+ * internationalized messages from all discovered services.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   @EnableI18nServer
+ *   @SpringBootApplication
+ *   public class I18nServerApplication {
+ *       public static void main(String[] args) {
+ *           SpringApplication.run(I18nServerApplication.class, args);
+ *       }
+ *   }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0

--- a/microsphere-i18n-spring-cloud-server/src/main/java/io/microsphere/i18n/spring/cloud/server/annotation/I18nServerConfiguration.java
+++ b/microsphere-i18n-spring-cloud-server/src/main/java/io/microsphere/i18n/spring/cloud/server/annotation/I18nServerConfiguration.java
@@ -38,7 +38,15 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Locale.getDefault;
 
 /**
- * The Configuration Class for I18n Server
+ * The Configuration Class for I18n Server that discovers services via {@link DiscoveryClient}
+ * and builds {@link PropertySourcesServiceMessageSource} instances for each service.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically imported via @EnableI18nServer
+ *   // Creates a CompositeServiceMessageSource containing one
+ *   // PropertySourcesServiceMessageSource per discovered service
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see PropertySourcesServiceMessageSource
@@ -53,6 +61,11 @@ public class I18nServerConfiguration {
     @Autowired
     private DiscoveryClient discoveryClient;
 
+    /**
+     * Creates a lazy {@link CompositeServiceMessageSource} bean populated on application start.
+     *
+     * @return an empty {@link CompositeServiceMessageSource}
+     */
     @Bean
     @Lazy
     public CompositeServiceMessageSource lazyCompositeServiceMessageSource() {

--- a/microsphere-i18n-spring-cloud-server/src/main/java/io/microsphere/i18n/spring/cloud/server/controller/I18nServerController.java
+++ b/microsphere-i18n-spring-cloud-server/src/main/java/io/microsphere/i18n/spring/cloud/server/controller/I18nServerController.java
@@ -25,7 +25,14 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 /**
- * The REST-Controler for I18n server
+ * The REST Controller for I18n server that exposes a {@code /messages} endpoint
+ * to retrieve all i18n messages.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // GET /messages
+ *   // Returns a map of resource name -> message code -> message value
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see PropertySourcesServiceMessageSource
@@ -37,6 +44,17 @@ public class I18nServerController {
     @Autowired
     private I18nEndpoint i18nEndpoint;
 
+    /**
+     * Returns all localized resource messages from the {@link I18nEndpoint}.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   // GET /messages
+     *   // Response: {"resource_name": {"code": "message"}, ...}
+     * }</pre>
+     *
+     * @return map of resource name to message code-value pairs
+     */
     @GetMapping("/messages")
     public Map<String, Map<String, String>> getMessages() {
         return i18nEndpoint.invoke();

--- a/microsphere-i18n-spring-cloud/pom.xml
+++ b/microsphere-i18n-spring-cloud/pom.xml
@@ -76,12 +76,6 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -112,14 +106,20 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microsphere-i18n-spring-cloud/src/main/java/io/microsphere/i18n/spring/cloud/autoconfigure/I18nCloudAutoConfiguration.java
+++ b/microsphere-i18n-spring-cloud/src/main/java/io/microsphere/i18n/spring/cloud/autoconfigure/I18nCloudAutoConfiguration.java
@@ -22,7 +22,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Import;
 
 /**
- * I18n Auto-Configuration for Spring Cloud
+ * I18n Auto-Configuration for Spring Cloud that enables dynamic reloading of
+ * i18n messages when Spring Cloud environment changes occur.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Auto-configured when spring-cloud-context is on classpath and i18n is enabled
+ *   // Listens for EnvironmentChangeEvent to trigger message source reloading
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0

--- a/microsphere-i18n-spring-cloud/src/main/java/io/microsphere/i18n/spring/cloud/event/ReloadableResourceServiceMessageSourceListener.java
+++ b/microsphere-i18n-spring-cloud/src/main/java/io/microsphere/i18n/spring/cloud/event/ReloadableResourceServiceMessageSourceListener.java
@@ -31,8 +31,17 @@ import java.util.Set;
 import static io.microsphere.i18n.spring.PropertySourcesServiceMessageSource.reloadAll;
 
 /**
- * * An {@link ApplicationListener} of {@link EnvironmentChangeEvent} to reload
- * {@link ServiceMessageSource} dynamically at the runtime.
+ * An {@link ApplicationListener} of {@link EnvironmentChangeEvent} to reload
+ * {@link ServiceMessageSource} dynamically at runtime when Spring Cloud
+ * environment properties change.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically imported via I18nCloudAutoConfiguration
+ *   // When an EnvironmentChangeEvent is fired (e.g. via /actuator/refresh),
+ *   // this listener reloads all PropertySourcesServiceMessageSource beans
+ *   // whose property names match the changed keys.
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see PropertySourcesServiceMessageSource

--- a/microsphere-i18n-spring/pom.xml
+++ b/microsphere-i18n-spring/pom.xml
@@ -68,8 +68,8 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -85,6 +85,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Hibernate Validator -->
         <dependency>
             <groupId>org.hibernate.validator</groupId>
@@ -96,12 +108,6 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/DelegatingServiceMessageSource.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/DelegatingServiceMessageSource.java
@@ -18,7 +18,17 @@ import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
 
 /**
- * The delegating {@link ServiceMessageSource} class is composited by the Spring {@link ServiceMessageSource} beans
+ * The delegating {@link ServiceMessageSource} class composited by Spring {@link ServiceMessageSource} beans.
+ * Registered as the primary {@link ServiceMessageSource} bean and auto-discovers all other
+ * {@link ServiceMessageSource} beans in the {@link BeanFactory}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically configured via @EnableI18n
+ *   @EnableI18n(sources = {"common", "test"})
+ *   public class AppConfig { }
+ *   // The DelegatingServiceMessageSource is registered as "serviceMessageSource" bean
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see AbstractServiceMessageSource
@@ -51,7 +61,9 @@ public class DelegatingServiceMessageSource extends CompositeServiceMessageSourc
     private List<ServiceMessageSource> findServiceMessageSourceBeans() {
         List<ServiceMessageSource> serviceMessageSources = new ArrayList<>(getSortedBeans(this.beanFactory, ServiceMessageSource.class));
         serviceMessageSources.remove(this);
-        logger.trace("Initializes the ServiceMessageSource Bean list : {}", serviceMessageSources);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Initializes the ServiceMessageSource Bean list : {}", serviceMessageSources);
+        }
         return serviceMessageSources;
     }
 

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/PropertySourcesServiceMessageSource.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/PropertySourcesServiceMessageSource.java
@@ -35,7 +35,17 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.hasText;
 
 /**
- * Spring {@link PropertySources} {@link ServiceMessageSource}
+ * Spring {@link PropertySources} {@link ServiceMessageSource} that loads i18n messages
+ * from Spring {@link Environment} properties and supports runtime reloading.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   PropertySourcesServiceMessageSource source = new PropertySourcesServiceMessageSource("test");
+ *   source.setEnvironment(environment);
+ *   source.setSupportedLocales(Arrays.asList(Locale.getDefault(), Locale.ENGLISH));
+ *   source.init();
+ *   String propertyName = source.getPropertyName(Locale.ENGLISH);
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
@@ -45,6 +55,11 @@ public class PropertySourcesServiceMessageSource extends PropertiesResourceServi
 
     private Environment environment;
 
+    /**
+     * Constructs with the given source identifier.
+     *
+     * @param source the source identifier
+     */
     public PropertySourcesServiceMessageSource(String source) {
         super(source);
     }
@@ -82,18 +97,36 @@ public class PropertySourcesServiceMessageSource extends PropertiesResourceServi
         return hasText(propertiesContent) ? ofList(new StringReader(propertiesContent)) : emptyList();
     }
 
+    /**
+     * Gets the properties content string from the Spring {@link Environment}.
+     *
+     * @param resource the resource identifier
+     * @return the properties content, or {@code null} if not found
+     */
     protected String getPropertiesContent(String resource) {
         String propertyName = getPropertyName(resource);
         String propertiesContent = environment.getProperty(propertyName);
         return propertiesContent;
     }
 
+    /**
+     * Gets the property name for the specified {@link Locale}.
+     *
+     * @param locale the target {@link Locale}
+     * @return the property name
+     */
     public String getPropertyName(Locale locale) {
         String resource = getResource(locale);
         String propertyName = getPropertyName(resource);
         return propertyName;
     }
 
+    /**
+     * Gets the property name for the specified resource.
+     *
+     * @param resource the resource identifier
+     * @return the property name
+     */
     public String getPropertyName(String resource) {
         String propertyName = resource;
         return propertyName;

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/annotation/EnableI18n.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/annotation/EnableI18n.java
@@ -40,6 +40,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * The feature could be disabled by the Spring property if
  * {@link I18nConstants#ENABLED_PROPERTY_NAME "microsphere.i18n.enabled"} is <code>false</code>
  *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   @EnableI18n(sources = {"common", "myapp"}, exposeMessageSource = true)
+ *   @Configuration
+ *   public class I18nConfig { }
+ * }</pre>
+ *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see I18nImportBeanDefinitionRegistrar
  * @see ServiceMessageSourceFactoryBean

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/annotation/I18nImportBeanDefinitionRegistrar.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/annotation/I18nImportBeanDefinitionRegistrar.java
@@ -52,7 +52,16 @@ import static org.springframework.context.support.AbstractApplicationContext.MES
 import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
 
 /**
- * I18n {@link ImportBeanDefinitionRegistrar}
+ * I18n {@link ImportBeanDefinitionRegistrar} that registers i18n-related Spring beans
+ * when {@link EnableI18n} is present.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically invoked via @EnableI18n annotation
+ *   @EnableI18n(sources = {"common"})
+ *   @Configuration
+ *   public class AppConfig { }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see EnableI18n
@@ -142,10 +151,12 @@ class I18nImportBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar
     private boolean isEnabled() {
         String propertyName = ENABLED_PROPERTY_NAME;
         boolean enabled = environment.getProperty(propertyName, boolean.class, DEFAULT_ENABLED);
-        logger.trace("Microsphere i18n is {} , cased by the Spring property[name : '{}', default value : '{}']",
-                enabled ? "enabled" : "disabled",
-                propertyName,
-                DEFAULT_ENABLED);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Microsphere i18n is {} , cased by the Spring property[name : '{}', default value : '{}']",
+                    enabled ? "enabled" : "disabled",
+                    propertyName,
+                    DEFAULT_ENABLED);
+        }
         return enabled;
     }
 }

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/beans/factory/ServiceMessageSourceFactoryBean.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/beans/factory/ServiceMessageSourceFactoryBean.java
@@ -46,7 +46,17 @@ import static org.springframework.util.StringUtils.hasText;
 import static org.springframework.util.StringUtils.parseLocale;
 
 /**
- * {@link ServiceMessageSource} {@link FactoryBean} Implementation
+ * {@link ServiceMessageSource} {@link FactoryBean} Implementation that creates and manages
+ * {@link ServiceMessageSource} beans based on Spring Factories configuration.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Typically auto-registered via @EnableI18n
+ *   @Bean
+ *   public ServiceMessageSourceFactoryBean myServiceMessageSource() {
+ *       return new ServiceMessageSourceFactoryBean("myapp");
+ *   }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see EnableI18n
@@ -69,10 +79,21 @@ public final class ServiceMessageSourceFactoryBean extends CompositeServiceMessa
 
     private int order;
 
+    /**
+     * Constructs with the given source identifier and lowest precedence order.
+     *
+     * @param source the source identifier
+     */
     public ServiceMessageSourceFactoryBean(String source) {
         this(source, LOWEST_PRECEDENCE);
     }
 
+    /**
+     * Constructs with the given source identifier and order.
+     *
+     * @param source the source identifier
+     * @param order  the order for bean sorting
+     */
     public ServiceMessageSourceFactoryBean(String source, int order) {
         this.source = source;
         setOrder(order);
@@ -133,11 +154,16 @@ public final class ServiceMessageSourceFactoryBean extends CompositeServiceMessa
         return order;
     }
 
+    /**
+     * Sets the order for this factory bean.
+     *
+     * @param order the order value
+     */
     public void setOrder(int order) {
         this.order = order;
     }
 
-    private List<AbstractServiceMessageSource> initServiceMessageSources() {
+    protected List<AbstractServiceMessageSource> initServiceMessageSources() {
         List<String> factoryNames = loadFactoryNames(AbstractServiceMessageSource.class, classLoader);
 
         Locale defaultLocale = resolveDefaultLocale(environment);
@@ -174,32 +200,40 @@ public final class ServiceMessageSourceFactoryBean extends CompositeServiceMessa
                 '}';
     }
 
-    private Locale resolveDefaultLocale(ConfigurableEnvironment environment) {
+    protected Locale resolveDefaultLocale(ConfigurableEnvironment environment) {
         String propertyName = DEFAULT_LOCALE_PROPERTY_NAME;
         String localeValue = environment.getProperty(propertyName);
         final Locale locale;
         if (!hasText(localeValue)) {
             locale = getDefaultLocale();
-            logger.trace("Default Locale configuration property [name : '{}'] not found, use default value: '{}'", propertyName, locale);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Default Locale configuration property [name : '{}'] not found, use default value: '{}'", propertyName, locale);
+            }
         } else {
             locale = parseLocale(localeValue);
-            logger.trace("Default Locale : '{}' parsed by configuration properties [name : '{}']", propertyName, locale);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Default Locale : '{}' parsed by configuration properties [name : '{}']", propertyName, locale);
+            }
         }
         return locale;
     }
 
-    private Set<Locale> resolveSupportedLocales(ConfigurableEnvironment environment) {
+    protected Set<Locale> resolveSupportedLocales(ConfigurableEnvironment environment) {
         final Set<Locale> supportedLocales;
         String propertyName = SUPPORTED_LOCALES_PROPERTY_NAME;
         List<String> locales = environment.getProperty(propertyName, List.class, emptyList());
         if (locales.isEmpty()) {
             supportedLocales = getSupportedLocales();
-            logger.trace("Support Locale set configuration property [name : '{}'] not found, use default value: {}", propertyName, supportedLocales);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Support Locale set configuration property [name : '{}'] not found, use default value: {}", propertyName, supportedLocales);
+            }
         } else {
             supportedLocales = locales.stream()
                     .map(StringUtils::parseLocale)
                     .collect(toSet());
-            logger.trace("The set of supported Locales parsed by configuration property [name : '{}']: {}", propertyName, supportedLocales);
+            if (logger.isTraceEnabled()) {
+                logger.trace("The set of supported Locales parsed by configuration property [name : '{}']: {}", propertyName, supportedLocales);
+            }
         }
         return unmodifiableSet(supportedLocales);
     }
@@ -207,7 +241,9 @@ public final class ServiceMessageSourceFactoryBean extends CompositeServiceMessa
     @Override
     public void onApplicationEvent(ResourceServiceMessageSourceChangedEvent event) {
         Iterable<String> changedResources = event.getChangedResources();
-        logger.trace("Receive event change resource: {}", changedResources);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Receive event change resource: {}", changedResources);
+        }
         super.reload(changedResources);
     }
 }

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/beans/factory/support/ServiceMessageSourceBeanLifecyclePostProcessor.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/beans/factory/support/ServiceMessageSourceBeanLifecyclePostProcessor.java
@@ -28,7 +28,17 @@ import static io.microsphere.util.StringUtils.isBlank;
 import static org.springframework.beans.factory.support.AbstractBeanDefinition.INFER_METHOD;
 
 /**
- * The PostProcessor processes the lifecycle of {@link ServiceMessageSource} Beans automatically.
+ * The PostProcessor that automatically processes the lifecycle of {@link ServiceMessageSource} beans
+ * by setting {@code init} and {@code destroy} method names on their bean definitions.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically registered via @EnableI18n
+ *   // Ensures ServiceMessageSource beans have proper init/destroy lifecycle methods
+ *   @EnableI18n
+ *   @Configuration
+ *   public class AppConfig { }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see ServiceMessageSource

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/constants/I18nConstants.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/constants/I18nConstants.java
@@ -8,7 +8,16 @@ import java.util.Locale;
 import static io.microsphere.annotation.ConfigurationProperty.APPLICATION_SOURCE;
 
 /**
- * Internationalization property constants
+ * Internationalization property constants used for Spring configuration properties.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // In application.properties:
+ *   // microsphere.i18n.enabled=true
+ *   // microsphere.i18n.sources=common,myapp
+ *   // microsphere.i18n.default-locale=zh_CN
+ *   // microsphere.i18n.supported-locales=zh_CN,en
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/context/I18nApplicationListener.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/context/I18nApplicationListener.java
@@ -35,7 +35,17 @@ import static io.microsphere.i18n.util.I18nUtils.destroyServiceMessageSource;
 import static io.microsphere.i18n.util.I18nUtils.setServiceMessageSource;
 
 /**
- * Internationalization {@link ApplicationListener}
+ * Internationalization {@link ApplicationListener} that initializes the global
+ * {@link ServiceMessageSource} on context refresh and destroys it on context close.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically registered via @EnableI18n
+ *   // Listens for ContextRefreshedEvent, ContextClosedEvent, and PropertySourcesChangedEvent
+ *   @EnableI18n
+ *   @Configuration
+ *   public class AppConfig { }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see SmartApplicationListener

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/context/MessageSourceAdapter.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/context/MessageSourceAdapter.java
@@ -17,7 +17,16 @@ import java.util.Locale;
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
 
 /**
- * Spring {@link MessageSource} Adapter
+ * Spring {@link MessageSource} Adapter that delegates message resolution to the
+ * underlying {@link ServiceMessageSource}, falling back to other {@link MessageSource} beans.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically registered when @EnableI18n(exposeMessageSource = true)
+ *   @Autowired
+ *   private MessageSource messageSource; // This is the MessageSourceAdapter
+ *   String msg = messageSource.getMessage("hello", new Object[]{"World"}, Locale.ENGLISH);
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see EnableI18n#exposeMessageSource()
@@ -31,6 +40,11 @@ public class MessageSourceAdapter implements MessageSource, SmartInitializingSin
 
     private BeanFactory beanFactory;
 
+    /**
+     * Constructs the adapter with the given {@link ServiceMessageSource}.
+     *
+     * @param serviceMessageSource the underlying {@link ServiceMessageSource}
+     */
     public MessageSourceAdapter(ServiceMessageSource serviceMessageSource) {
         this.serviceMessageSource = serviceMessageSource;
         this.defaultMessageSources = new ArrayList<>(2);

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/context/ResourceServiceMessageSourceChangedEvent.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/context/ResourceServiceMessageSourceChangedEvent.java
@@ -6,7 +6,15 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.ApplicationContextEvent;
 
 /**
- * {@link ResourceServiceMessageSource} Changed {@link ApplicationEvent Event}
+ * {@link ResourceServiceMessageSource} Changed {@link ApplicationEvent Event},
+ * published when i18n resource files are modified at runtime.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   ApplicationContext context = ...;
+ *   context.publishEvent(new ResourceServiceMessageSourceChangedEvent(
+ *       context, Arrays.asList("META-INF/i18n/test/i18n_messages_en.properties")));
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see ApplicationEvent
@@ -16,11 +24,22 @@ public class ResourceServiceMessageSourceChangedEvent extends ApplicationContext
 
     private final Iterable<String> changedResources;
 
+    /**
+     * Constructs the event.
+     *
+     * @param source           the {@link ApplicationContext} that publishes this event
+     * @param changedResources the changed resource paths
+     */
     public ResourceServiceMessageSourceChangedEvent(ApplicationContext source, Iterable<String> changedResources) {
         super(source);
         this.changedResources = changedResources;
     }
 
+    /**
+     * Gets the changed resource paths.
+     *
+     * @return the changed resource paths
+     */
     public Iterable<String> getChangedResources() {
         return changedResources;
     }

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/util/I18nBeanUtils.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/util/I18nBeanUtils.java
@@ -34,7 +34,16 @@ import static io.microsphere.util.ClassUtils.cast;
 import static org.springframework.context.support.AbstractApplicationContext.MESSAGE_SOURCE_BEAN_NAME;
 
 /**
- * The utilities class for i18n Beans
+ * The utilities class for i18n Beans, providing methods to retrieve i18n-related
+ * beans from a {@link BeanFactory}.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   BeanFactory beanFactory = applicationContext;
+ *   ServiceMessageSource source = I18nBeanUtils.getServiceMessageSource(beanFactory);
+ *   MessageSource messageSource = I18nBeanUtils.getMessageSource(beanFactory);
+ *   MessageSourceAdapter adapter = I18nBeanUtils.getMessageSourceAdapter(beanFactory);
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see EnableI18n

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/util/LocaleUtils.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/util/LocaleUtils.java
@@ -24,7 +24,13 @@ import java.util.Locale;
 import static org.springframework.context.i18n.LocaleContextHolder.getLocaleContext;
 
 /**
- * The utilities class for {@link Locale} in the Spring
+ * The utilities class for {@link Locale} in the Spring framework.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   Locale locale = LocaleUtils.getLocaleFromLocaleContext();
+ *   // returns the Locale from the current thread's LocaleContext, or null
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see LocaleContext

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/validation/beanvalidation/I18nLocalValidatorFactoryBeanPostProcessor.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/validation/beanvalidation/I18nLocalValidatorFactoryBeanPostProcessor.java
@@ -15,7 +15,17 @@ import static org.springframework.util.ClassUtils.isPresent;
 
 
 /**
- * Internationalization {@link BeanPostProcessor} for {@link LocalValidatorFactoryBean}.
+ * Internationalization {@link BeanPostProcessor} for {@link LocalValidatorFactoryBean}
+ * that sets the i18n {@link MessageSourceAdapter} as the validation message source.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically registered via @EnableI18n when Jakarta Validation API is on classpath
+ *   // Associates LocalValidatorFactoryBean with the i18n MessageSourceAdapter
+ *   @EnableI18n
+ *   @Configuration
+ *   public class AppConfig { }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see LocalValidatorFactoryBean#setValidationMessageSource(MessageSource)
@@ -31,6 +41,11 @@ public class I18nLocalValidatorFactoryBeanPostProcessor extends GenericBeanPostP
 
     private final ObjectProvider<MessageSourceAdapter> messageSourceAdapterProvider;
 
+    /**
+     * Constructs with the given {@link MessageSourceAdapter} provider.
+     *
+     * @param messageSourceAdapterProvider the {@link MessageSourceAdapter} provider
+     */
     public I18nLocalValidatorFactoryBeanPostProcessor(ObjectProvider<MessageSourceAdapter> messageSourceAdapterProvider) {
         this.messageSourceAdapterProvider = messageSourceAdapterProvider;
     }
@@ -39,10 +54,18 @@ public class I18nLocalValidatorFactoryBeanPostProcessor extends GenericBeanPostP
     protected void processBeforeInitialization(LocalValidatorFactoryBean localValidatorFactoryBean, String beanName) throws BeansException {
         messageSourceAdapterProvider.ifAvailable(messageSourceAdapter -> {
             localValidatorFactoryBean.setValidationMessageSource(messageSourceAdapter);
-            logger.trace("LocalValidatorFactoryBean[name : '{}'] is associated with MessageSource : {}", beanName, messageSourceAdapter);
+            if (logger.isTraceEnabled()) {
+                logger.trace("LocalValidatorFactoryBean[name : '{}'] is associated with MessageSource : {}", beanName, messageSourceAdapter);
+            }
         });
     }
 
+    /**
+     * Checks whether Jakarta Validation API is present on the classpath.
+     *
+     * @param classLoader the class loader to check
+     * @return {@code true} if the ValidatorFactory class is available
+     */
     public static boolean isValidatorFactoryPresent(ClassLoader classLoader) {
         return isPresent(VALIDATOR_FACTORY_CLASS_NAME, classLoader);
     }

--- a/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/web/servlet/AcceptHeaderLocaleResolverBeanPostProcessor.java
+++ b/microsphere-i18n-spring/src/main/java/io/microsphere/i18n/spring/web/servlet/AcceptHeaderLocaleResolverBeanPostProcessor.java
@@ -37,8 +37,17 @@ import static io.microsphere.logging.LoggerFactory.getLogger;
 import static org.springframework.util.ClassUtils.isPresent;
 
 /**
- * The {@link BeanPostProcessor} to set the default {@link Locale locale} and supported {@link Locale locales}
- * into {@link AcceptHeaderLocaleResolver}.
+ * The {@link BeanPostProcessor} to set the default {@link Locale} and supported {@link Locale locales}
+ * into {@link AcceptHeaderLocaleResolver} from the {@link ServiceMessageSource} configuration.
+ *
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ *   // Automatically registered via @EnableI18n when Spring Web MVC is on classpath
+ *   // Configures AcceptHeaderLocaleResolver with i18n-supported locales
+ *   @EnableI18n
+ *   @Configuration
+ *   public class WebConfig { }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see AcceptHeaderLocaleResolver
@@ -62,7 +71,9 @@ public class AcceptHeaderLocaleResolverBeanPostProcessor extends GenericBeanPost
         Set<Locale> supportedLocales = serviceMessageSource.getSupportedLocales();
         acceptHeaderLocaleResolver.setDefaultLocale(defaultLocale);
         acceptHeaderLocaleResolver.setSupportedLocales(ofList(supportedLocales));
-        logger.trace("AcceptHeaderLocaleResolver Bean associated with default Locale : '{}' , list of supported Locales : {}", defaultLocale, supportedLocales);
+        if (logger.isTraceEnabled()) {
+            logger.trace("AcceptHeaderLocaleResolver Bean associated with default Locale : '{}' , list of supported Locales : {}", defaultLocale, supportedLocales);
+        }
     }
 
     @Override
@@ -70,6 +81,12 @@ public class AcceptHeaderLocaleResolverBeanPostProcessor extends GenericBeanPost
         this.context = context;
     }
 
+    /**
+     * Checks whether {@link AcceptHeaderLocaleResolver} is present on the classpath.
+     *
+     * @param classLoader the class loader to check
+     * @return {@code true} if the class is available
+     */
     public static boolean isAcceptHeaderLocaleResolverPresent(ClassLoader classLoader) {
         return isPresent(CLASS_NAME, classLoader);
     }

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/AbstractSpringTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/AbstractSpringTest.java
@@ -16,15 +16,15 @@
  */
 package io.microsphere.i18n;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import static io.microsphere.i18n.util.I18nUtils.destroyServiceMessageSource;
 import static java.util.Locale.SIMPLIFIED_CHINESE;
 import static java.util.Locale.setDefault;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.context.i18n.LocaleContextHolder.resetLocaleContext;
 
 /**
@@ -37,19 +37,19 @@ public abstract class AbstractSpringTest {
 
     public static final String TEST_SOURCE = "test";
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    static void beforeClass() {
         // Set the simplified Chinese as the default Locale
         setDefault(SIMPLIFIED_CHINESE);
     }
 
-    @Before
-    public void before() throws Throwable {
+    @BeforeEach
+    protected void before() throws Throwable {
         resetLocaleContext();
     }
 
-    @AfterClass
-    public static void afterClass() throws Throwable {
+    @AfterAll
+    static void afterClass() throws Throwable {
         destroyServiceMessageSource();
         resetLocaleContext();
     }

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/DelegatingServiceMessageSourceTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/DelegatingServiceMessageSourceTest.java
@@ -19,10 +19,11 @@ package io.microsphere.i18n.spring;
 
 
 import io.microsphere.i18n.EmptyServiceMessageSource;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.Test;
 
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * {@link DelegatingServiceMessageSource} Test
@@ -31,10 +32,11 @@ import static org.junit.Assert.assertNull;
  * @see DelegatingServiceMessageSource
  * @since 1.0.0
  */
-public class DelegatingServiceMessageSourceTest {
+@SpringLoggingTest
+class DelegatingServiceMessageSourceTest {
 
     @Test
-    public void test() {
+    void test() {
         testInSpringContainer(context -> {
             DelegatingServiceMessageSource delegatingServiceMessageSource = context.getBean(DelegatingServiceMessageSource.class);
             assertNull(delegatingServiceMessageSource.getMessage("test"));

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/PropertySourcesServiceMessageSourceTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/PropertySourcesServiceMessageSourceTest.java
@@ -4,8 +4,8 @@ import io.microsphere.i18n.AbstractSpringTest;
 import io.microsphere.i18n.DefaultServiceMessageSource;
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
 import io.microsphere.io.StringBuilderWriter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.mock.env.MockEnvironment;
@@ -21,10 +21,10 @@ import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContai
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Locale.SIMPLIFIED_CHINESE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link PropertySourcesServiceMessageSource} Test
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  * @see PropertySourcesServiceMessageSource
  * @since 1.0.0
  */
-public class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest {
+class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest {
 
     private MockEnvironment environment;
 
@@ -43,8 +43,8 @@ public class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest 
 
     private String testPropertyName = "test.i18n_messages_zh_CN.properties";
 
-    @Before
-    public void before() throws Throwable {
+    @BeforeEach
+    protected void before() throws Throwable {
         super.before();
         this.environment = new MockEnvironment();
         this.initEnvironment();
@@ -63,12 +63,12 @@ public class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest 
     }
 
     @Test
-    public void test() {
+    void test() {
         assertGetMessage(this.propertySourcesServiceMessageSource);
     }
 
     @Test
-    public void testCanReload() {
+    void testCanReload() {
         assertTrue(this.propertySourcesServiceMessageSource.canReload(this.testPropertyName));
         assertTrue(this.propertySourcesServiceMessageSource.canReload(ofSet(this.testPropertyName)));
 
@@ -80,14 +80,14 @@ public class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest 
     }
 
     @Test
-    public void testFindAllPropertySourcesServiceMessageSourcesOnNoBeanDefinition() {
+    void testFindAllPropertySourcesServiceMessageSourcesOnNoBeanDefinition() {
         testInSpringContainer(context -> {
             assertTrue(findAllPropertySourcesServiceMessageSources(context).isEmpty());
         });
     }
 
     @Test
-    public void testFindAllPropertySourcesServiceMessageSourcesOnSingleBeanDefinition() {
+    void testFindAllPropertySourcesServiceMessageSourcesOnSingleBeanDefinition() {
         testInSpringContainer(context -> {
             List<PropertySourcesServiceMessageSource> allPropertySourcesServiceMessageSources = findAllPropertySourcesServiceMessageSources(context);
             assertEquals(1, allPropertySourcesServiceMessageSources.size());
@@ -97,7 +97,7 @@ public class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest 
     }
 
     @Test
-    public void testFindAllPropertySourcesServiceMessageSourcesOnDelegatingBeanDefinition() {
+    void testFindAllPropertySourcesServiceMessageSourcesOnDelegatingBeanDefinition() {
         testInSpringContainer(context -> {
             List<PropertySourcesServiceMessageSource> allPropertySourcesServiceMessageSources = findAllPropertySourcesServiceMessageSources(context);
             assertEquals(1, allPropertySourcesServiceMessageSources.size());
@@ -107,17 +107,17 @@ public class PropertySourcesServiceMessageSourceTest extends AbstractSpringTest 
     }
 
     @Test
-    public void testFindAllPropertySourcesServiceMessageSourcesOnEmptyCollection() {
+    void testFindAllPropertySourcesServiceMessageSourcesOnEmptyCollection() {
         assertSame(emptyList(), findAllPropertySourcesServiceMessageSources(emptyList()));
     }
 
     @Test
-    public void testGetResource() {
+    void testGetResource() {
         assertEquals(this.testPropertyName, this.propertySourcesServiceMessageSource.getResource("i18n_messages_zh_CN.properties"));
     }
 
     @Test
-    public void testGetPropertyName() {
+    void testGetPropertyName() {
         assertEquals(this.testPropertyName, this.propertySourcesServiceMessageSource.getPropertyName(SIMPLIFIED_CHINESE));
     }
 

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/annotation/EnableI18nTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/annotation/EnableI18nTest.java
@@ -3,18 +3,18 @@ package io.microsphere.i18n.spring.annotation;
 import io.microsphere.i18n.AbstractSpringTest;
 import io.microsphere.i18n.ServiceMessageSource;
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static io.microsphere.i18n.util.I18nUtils.serviceMessageSource;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.US;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * {@link EnableI18n} Test
@@ -22,17 +22,17 @@ import static org.junit.Assert.assertSame;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @since 1.0.0
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
         TestSourceEnableI18nConfiguration.class
 })
-public class EnableI18nTest extends AbstractSpringTest {
+class EnableI18nTest extends AbstractSpringTest {
 
     @Autowired
     private ServiceMessageSource serviceMessageSource;
 
     @Test
-    public void testGetMessage() {
+    void testGetMessage() {
         assertGetMessage(this.serviceMessageSource);
 
         // Test English, because the English Message resource does not exist
@@ -43,7 +43,7 @@ public class EnableI18nTest extends AbstractSpringTest {
     }
 
     @Test
-    public void testCommonServiceMessageSource() {
+    void testCommonServiceMessageSource() {
         assertSame(serviceMessageSource(), serviceMessageSource);
     }
 }

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/annotation/I18nImportBeanDefinitionRegistrarTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/annotation/I18nImportBeanDefinitionRegistrarTest.java
@@ -27,15 +27,16 @@ import io.microsphere.i18n.spring.context.I18nApplicationListener;
 import io.microsphere.i18n.spring.context.MessageSourceAdapter;
 import io.microsphere.i18n.spring.validation.beanvalidation.I18nLocalValidatorFactoryBeanPostProcessor;
 import io.microsphere.i18n.spring.web.servlet.AcceptHeaderLocaleResolverBeanPostProcessor;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSource;
 
 import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
 import static java.lang.ClassLoader.getSystemClassLoader;
 import static java.lang.Thread.currentThread;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link I18nImportBeanDefinitionRegistrar} Test
@@ -44,10 +45,11 @@ import static org.junit.Assert.assertTrue;
  * @see I18nImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
-public class I18nImportBeanDefinitionRegistrarTest {
+@SpringLoggingTest
+class I18nImportBeanDefinitionRegistrarTest {
 
     @Test
-    public void testOnSpecifiedSources() {
+    void testOnSpecifiedSources() {
         testInSpringContainer((context, environment) -> {
             assertTrue(isBeanPresent(context, ServiceMessageSourceFactoryBean.class));
             assertTrue(isBeanPresent(context, MessageSourceAdapter.class));
@@ -63,7 +65,7 @@ public class I18nImportBeanDefinitionRegistrarTest {
     }
 
     @Test
-    public void testOnDisabled() {
+    void testOnDisabled() {
         testInSpringContainer((context, environment) -> {
             assertFalse(isBeanPresent(context, ServiceMessageSourceFactoryBean.class));
             assertFalse(isBeanPresent(context, MessageSourceAdapter.class));
@@ -76,7 +78,7 @@ public class I18nImportBeanDefinitionRegistrarTest {
     }
 
     @Test
-    public void testOnUnexposedMessageSource() {
+    void testOnUnexposedMessageSource() {
         testInSpringContainer((context, environment) -> {
             assertTrue(isBeanPresent(context, ServiceMessageSourceFactoryBean.class));
             assertFalse(isBeanPresent(context, MessageSourceAdapter.class));
@@ -89,7 +91,7 @@ public class I18nImportBeanDefinitionRegistrarTest {
     }
 
     @Test
-    public void testOnBeanClassAbsent() {
+    void testOnBeanClassAbsent() {
         ClassLoader classLoader = currentThread().getContextClassLoader();
         try {
             currentThread().setContextClassLoader(getSystemClassLoader().getParent());

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/beans/factory/ServiceMessageSourceFactoryBeanTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/beans/factory/ServiceMessageSourceFactoryBeanTest.java
@@ -4,26 +4,33 @@ import io.microsphere.i18n.AbstractSpringTest;
 import io.microsphere.i18n.ServiceMessageSource;
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
 import io.microsphere.i18n.spring.context.ResourceServiceMessageSourceChangedEvent;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.microsphere.logging.test.jupiter.LoggingLevelsTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.env.MockPropertySource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Locale;
+import java.util.Set;
 
 import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.collection.Sets.ofSet;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.FRANCE;
 import static java.util.Locale.US;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static java.util.Locale.getDefault;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.context.i18n.LocaleContextHolder.resetLocaleContext;
 import static org.springframework.context.i18n.LocaleContextHolder.setLocale;
 
 /**
@@ -33,7 +40,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.setLocale;
  * @see ServiceMessageSourceFactoryBean
  * @since 1.0.0
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
         TestSourceEnableI18nConfiguration.class
 })
@@ -41,7 +48,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.setLocale;
         "microsphere.i18n.default-locale=en",
         "microsphere.i18n.supported-locales=en",
 })
-public class ServiceMessageSourceFactoryBeanTest extends AbstractSpringTest {
+class ServiceMessageSourceFactoryBeanTest extends AbstractSpringTest {
 
     @Autowired
     private ServiceMessageSource serviceMessageSource;
@@ -60,8 +67,8 @@ public class ServiceMessageSourceFactoryBeanTest extends AbstractSpringTest {
 
     private MockPropertySource propertySource;
 
-    @Before
-    public void before() throws Throwable {
+    @BeforeEach
+    protected void before() throws Throwable {
         super.before();
         setLocale(ENGLISH);
         propertySource = new MockPropertySource("mock");
@@ -69,7 +76,7 @@ public class ServiceMessageSourceFactoryBeanTest extends AbstractSpringTest {
     }
 
     @Test
-    public void testGetMessage() {
+    void testGetMessage() {
         assertEquals("test-a", this.serviceMessageSource.getMessage("a"));
         assertEquals("Hello,World", this.serviceMessageSource.getMessage("hello", "World"));
 
@@ -83,41 +90,75 @@ public class ServiceMessageSourceFactoryBeanTest extends AbstractSpringTest {
     }
 
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         assertEquals(ENGLISH, this.serviceMessageSource.getLocale());
-        assertEquals(ENGLISH, serviceMessageSourceFactoryBean.getLocale());
+        assertEquals(ENGLISH, this.serviceMessageSourceFactoryBean.getLocale());
 
         // Test US
         setLocale(US);
         assertEquals(US, this.serviceMessageSource.getLocale());
-        assertEquals(US, serviceMessageSourceFactoryBean.getLocale());
+        assertEquals(US, this.serviceMessageSourceFactoryBean.getLocale());
+
+        // Reset
+        resetLocaleContext();
+        assertEquals(getDefault(), this.serviceMessageSource.getLocale());
+        assertEquals(getDefault(), this.serviceMessageSourceFactoryBean.getLocale());
     }
 
     @Test
-    public void testGetDefaultLocale() {
+    void testGetDefaultLocale() {
         assertEquals(ENGLISH, this.serviceMessageSource.getDefaultLocale());
-        assertEquals(ENGLISH, serviceMessageSourceFactoryBean.getDefaultLocale());
+        assertEquals(ENGLISH, this.serviceMessageSourceFactoryBean.getDefaultLocale());
     }
 
     @Test
-    public void testGetSupportedLocales() {
+    void testGetSupportedLocales() {
         assertEquals(ofSet(ENGLISH), this.serviceMessageSource.getSupportedLocales());
-        assertEquals(ofSet(ENGLISH), serviceMessageSourceFactoryBean.getSupportedLocales());
+        assertEquals(ofSet(ENGLISH), this.serviceMessageSourceFactoryBean.getSupportedLocales());
     }
 
     @Test
-    public void testGetSource() {
-        assertEquals(TEST_SOURCE, serviceMessageSourceFactoryBean.getSource());
+    void testGetSource() {
+        assertEquals(TEST_SOURCE, this.serviceMessageSourceFactoryBean.getSource());
     }
 
     @Test
-    public void testSetOrder() {
-        serviceMessageSourceFactoryBean.setOrder(1);
-        assertEquals(1, serviceMessageSourceFactoryBean.getOrder());
+    void testSetOrder() {
+        this.serviceMessageSourceFactoryBean.setOrder(1);
+        assertEquals(1, this.serviceMessageSourceFactoryBean.getOrder());
     }
 
     @Test
-    public void testToString() {
+    @LoggingLevelsTest(levels = "ERROR")
+    void testResolveSupportedLocale() {
+        Locale locale = this.serviceMessageSourceFactoryBean.resolveDefaultLocale(this.environment);
+        assertEquals(ENGLISH, locale);
+
+        MockEnvironment environment = new MockEnvironment();
+        locale = this.serviceMessageSourceFactoryBean.resolveDefaultLocale(environment);
+        assertEquals(this.serviceMessageSourceFactoryBean.getDefaultLocale(), locale);
+    }
+
+    @Test
+    @LoggingLevelsTest(levels = "ERROR")
+    void testResolveSupportedLocales() {
+        Set<Locale> locales = this.serviceMessageSourceFactoryBean.resolveSupportedLocales(this.environment);
+        assertEquals(ofSet(ENGLISH), locales);
+
+        MockEnvironment environment = new MockEnvironment();
+        locales = this.serviceMessageSourceFactoryBean.resolveSupportedLocales(environment);
+        assertEquals(this.serviceMessageSourceFactoryBean.getDefaultSupportedLocales(), locales);
+    }
+
+    @Test
+    @LoggingLevelsTest(levels = "ERROR")
+    void testOnApplicationEvent() {
+        ResourceServiceMessageSourceChangedEvent event = new ResourceServiceMessageSourceChangedEvent(this.context, ofList("test.i18n_messages_en.properties"));
+        this.serviceMessageSourceFactoryBean.onApplicationEvent(event);
+    }
+
+    @Test
+    void testToString() {
         assertNotNull(this.serviceMessageSource.toString());
     }
 }

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/beans/factory/support/ServiceMessageSourceBeanLifecyclePostProcessorTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/beans/factory/support/ServiceMessageSourceBeanLifecyclePostProcessorTest.java
@@ -20,15 +20,15 @@ package io.microsphere.i18n.spring.beans.factory.support;
 
 import io.microsphere.i18n.ServiceMessageSource;
 import io.microsphere.i18n.spring.DelegatingServiceMessageSource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.beans.factory.support.AbstractBeanDefinition.INFER_METHOD;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
 
@@ -39,17 +39,17 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * @see ServiceMessageSourceBeanLifecyclePostProcessor
  * @since 1.0.0
  */
-public class ServiceMessageSourceBeanLifecyclePostProcessorTest {
+class ServiceMessageSourceBeanLifecyclePostProcessorTest {
 
     private ServiceMessageSourceBeanLifecyclePostProcessor postProcessor;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         this.postProcessor = new ServiceMessageSourceBeanLifecyclePostProcessor();
     }
 
     @Test
-    public void testPostProcessMergedBeanDefinition() {
+    void testPostProcessMergedBeanDefinition() {
         testPostProcessMergedBeanDefinition(ServiceMessageSource.class, beanDefinition -> {
             assertEquals("init", beanDefinition.getInitMethodName());
             assertEquals("destroy", beanDefinition.getDestroyMethodName());

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/context/I18nApplicationListenerTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/context/I18nApplicationListenerTest.java
@@ -22,7 +22,7 @@ import io.microsphere.i18n.AbstractSpringTest;
 import io.microsphere.i18n.ServiceMessageSource;
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
 import io.microsphere.spring.config.env.event.PropertySourcesChangedEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockPropertySource;
 
 import static io.microsphere.i18n.EmptyServiceMessageSource.INSTANCE;
@@ -30,8 +30,8 @@ import static io.microsphere.i18n.spring.util.I18nBeanUtils.getServiceMessageSou
 import static io.microsphere.i18n.util.I18nUtils.serviceMessageSource;
 import static io.microsphere.spring.config.env.event.PropertySourceChangedEvent.added;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * {@link I18nApplicationListener} Test
@@ -40,10 +40,10 @@ import static org.junit.Assert.assertSame;
  * @see I18nApplicationListener
  * @since 1.0.0
  */
-public class I18nApplicationListenerTest extends AbstractSpringTest {
+class I18nApplicationListenerTest extends AbstractSpringTest {
 
     @Test
-    public void test() {
+    void test() {
         testInSpringContainer((context, environment) -> {
             ServiceMessageSource serviceMessageSource = getServiceMessageSource(context);
             assertSame(serviceMessageSource(), serviceMessageSource);

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/context/MessageSourceAdapterTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/context/MessageSourceAdapterTest.java
@@ -21,7 +21,7 @@ package io.microsphere.i18n.spring.context;
 import io.microsphere.i18n.AbstractSpringTest;
 import io.microsphere.i18n.DefaultServiceMessageSource;
 import io.microsphere.i18n.EmptyServiceMessageSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.ResourceBundleMessageSource;
@@ -32,9 +32,9 @@ import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContai
 import static io.microsphere.util.ArrayUtils.EMPTY_OBJECT_ARRAY;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static java.util.Locale.getDefault;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * {@link MessageSourceAdapter} Test
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertNull;
  * @see MessageSourceAdapter
  * @since 1.0.0
  */
-public class MessageSourceAdapterTest extends AbstractSpringTest {
+class MessageSourceAdapterTest extends AbstractSpringTest {
 
     private static final String testCode = "test.value";
 
@@ -74,7 +74,7 @@ public class MessageSourceAdapterTest extends AbstractSpringTest {
     private MessageSourceResolvable emptyMessageSourceResolvable = () -> new String[0];
 
     @Test
-    public void testOnNoMessageSourceBean() {
+    void testOnNoMessageSourceBean() {
         testInSpringContainer(context -> {
             MessageSourceAdapter messageSourceAdapter = context.getBean(MessageSourceAdapter.class);
             assertNull(messageSourceAdapter.getMessage(testCode, args, locale));
@@ -85,7 +85,7 @@ public class MessageSourceAdapterTest extends AbstractSpringTest {
     }
 
     @Test
-    public void test() {
+    void test() {
         testInSpringContainer(context -> {
             MessageSourceAdapter messageSourceAdapter = context.getBean(MessageSourceAdapter.class);
             assertEquals("测试-a", messageSourceAdapter.getMessage("a", args, locale));

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/util/I18nBeanUtilsTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/util/I18nBeanUtilsTest.java
@@ -23,7 +23,7 @@ import io.microsphere.i18n.spring.DelegatingServiceMessageSource;
 import io.microsphere.i18n.spring.config.DisabledEnableI18nConfiguration;
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
 import io.microsphere.i18n.spring.context.MessageSourceAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.DelegatingMessageSource;
@@ -32,10 +32,10 @@ import static io.microsphere.i18n.spring.util.I18nBeanUtils.getMessageSource;
 import static io.microsphere.i18n.spring.util.I18nBeanUtils.getMessageSourceAdapter;
 import static io.microsphere.i18n.spring.util.I18nBeanUtils.getServiceMessageSource;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.context.support.AbstractApplicationContext.MESSAGE_SOURCE_BEAN_NAME;
 
 /**
@@ -45,25 +45,25 @@ import static org.springframework.context.support.AbstractApplicationContext.MES
  * @see I18nBeanUtils
  * @since 1.0.0
  */
-public class I18nBeanUtilsTest {
+class I18nBeanUtilsTest {
 
     @Test
-    public void testGetMessageSourceWithoutMessageSourceBean() {
+    void testGetMessageSourceWithoutMessageSourceBean() {
         testInSpringContainer(this::assertDefaultMessageSource);
     }
 
     @Test
-    public void testGetMessageSourceWithoutMessageSourceBeanExposure() {
+    void testGetMessageSourceWithoutMessageSourceBeanExposure() {
         testInSpringContainer(this::assertDefaultMessageSource, DisabledEnableI18nConfiguration.class);
     }
 
     @Test
-    public void testGetMessageSource() {
+    void testGetMessageSource() {
         testInSpringContainer(this::assertMessageSourceAdapter, TestSourceEnableI18nConfiguration.class);
     }
 
     @Test
-    public void testGetServiceMessageSourceWithoutDefinition() {
+    void testGetServiceMessageSourceWithoutDefinition() {
         testInSpringContainer(context -> {
             ServiceMessageSource serviceMessageSource = getServiceMessageSource(context);
             assertNull(serviceMessageSource);
@@ -71,7 +71,7 @@ public class I18nBeanUtilsTest {
     }
 
     @Test
-    public void testGetServiceMessageSource() {
+    void testGetServiceMessageSource() {
         testInSpringContainer(context -> {
             ServiceMessageSource serviceMessageSource = getServiceMessageSource(context);
             assertNotNull(serviceMessageSource);

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/validation/beanvalidation/I18NLocalValidatorFactoryBeanPostProcessorTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/validation/beanvalidation/I18NLocalValidatorFactoryBeanPostProcessorTest.java
@@ -20,14 +20,15 @@ package io.microsphere.i18n.spring.validation.beanvalidation;
 
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
 import io.microsphere.i18n.spring.context.MessageSourceAdapter;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.Test;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.validation.beanvalidation.LocaleContextMessageInterpolator;
 
 import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link I18nLocalValidatorFactoryBeanPostProcessor} Test
@@ -36,24 +37,25 @@ import static org.junit.Assert.assertTrue;
  * @see I18nLocalValidatorFactoryBeanPostProcessor
  * @since 1.0.0
  */
-public class I18NLocalValidatorFactoryBeanPostProcessorTest {
+@SpringLoggingTest
+class I18NLocalValidatorFactoryBeanPostProcessorTest {
 
     @Test
-    public void testOnNoLocalValidatorFactoryBean() {
+    void testOnNoLocalValidatorFactoryBean() {
         testInSpringContainer(context -> {
             assertFalse(isBeanPresent(context, LocalValidatorFactoryBean.class));
         }, TestSourceEnableI18nConfiguration.class);
     }
 
     @Test
-    public void testOnNoMessageSourceAdapterBean() {
+    void testOnNoMessageSourceAdapterBean() {
         testInSpringContainer(context -> {
             assertTrue(isBeanPresent(context, LocalValidatorFactoryBean.class));
         }, TestSourceEnableI18nConfiguration.class, LocalValidatorFactoryBean.class);
     }
 
     @Test
-    public void test() {
+    void test() {
         testInSpringContainer(context -> {
             assertTrue(isBeanPresent(context, MessageSourceAdapter.class));
             LocalValidatorFactoryBean localValidatorFactoryBean = context.getBean(LocalValidatorFactoryBean.class);

--- a/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/web/servlet/AcceptHeaderLocaleResolverBeanPostProcessorTest.java
+++ b/microsphere-i18n-spring/src/test/java/io/microsphere/i18n/spring/web/servlet/AcceptHeaderLocaleResolverBeanPostProcessorTest.java
@@ -20,14 +20,15 @@ package io.microsphere.i18n.spring.web.servlet;
 
 import io.microsphere.i18n.ServiceMessageSource;
 import io.microsphere.i18n.spring.config.TestSourceEnableI18nConfiguration;
-import org.junit.Test;
+import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 
 import static io.microsphere.collection.ListUtils.ofList;
 import static io.microsphere.i18n.spring.util.I18nBeanUtils.getServiceMessageSource;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link AcceptHeaderLocaleResolverBeanPostProcessor} Test
@@ -36,10 +37,11 @@ import static org.junit.Assert.assertEquals;
  * @see AcceptHeaderLocaleResolverBeanPostProcessor
  * @since 1.0.0
  */
-public class AcceptHeaderLocaleResolverBeanPostProcessorTest {
+@SpringLoggingTest
+class AcceptHeaderLocaleResolverBeanPostProcessorTest {
 
     @Test
-    public void test() {
+    void test() {
         testInSpringContainer(context -> {
             ServiceMessageSource serviceMessageSource = getServiceMessageSource(context);
             AcceptHeaderLocaleResolver localeResolver = context.getBean(AcceptHeaderLocaleResolver.class);

--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    https://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -19,298 +19,277 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Maven Start Up Batch script
-#
-# Required ENV vars:
-# ------------------
-#   JAVA_HOME - location of a JDK home dir
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
-#   M2_HOME - location of maven2's installed home dir
-#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
-#     e.g. to debug Maven itself, use
-#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
 # ----------------------------------------------------------------------------
 
-if [ -z "$MAVEN_SKIP_RC" ] ; then
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
 
-  if [ -f /usr/local/etc/mavenrc ] ; then
-    . /usr/local/etc/mavenrc
-  fi
-
-  if [ -f /etc/mavenrc ] ; then
-    . /etc/mavenrc
-  fi
-
-  if [ -f "$HOME/.mavenrc" ] ; then
-    . "$HOME/.mavenrc"
-  fi
-
-fi
-
-# OS specific support.  $var _must_ be set to either true or false.
-cygwin=false;
-darwin=false;
-mingw=false
-case "`uname`" in
-  CYGWIN*) cygwin=true ;;
-  MINGW*) mingw=true;;
-  Darwin*) darwin=true
-    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
-    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
-    if [ -z "$JAVA_HOME" ]; then
-      if [ -x "/usr/libexec/java_home" ]; then
-        export JAVA_HOME="`/usr/libexec/java_home`"
-      else
-        export JAVA_HOME="/Library/Java/Home"
-      fi
-    fi
-    ;;
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
 esac
 
-if [ -z "$JAVA_HOME" ] ; then
-  if [ -r /etc/gentoo-release ] ; then
-    JAVA_HOME=`java-config --jre-home`
-  fi
-fi
-
-if [ -z "$M2_HOME" ] ; then
-  ## resolve links - $0 may be a link to maven's home
-  PRG="$0"
-
-  # need this for relative symlinks
-  while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
-    if expr "$link" : '/.*' > /dev/null; then
-      PRG="$link"
-    else
-      PRG="`dirname "$PRG"`/$link"
-    fi
-  done
-
-  saveddir=`pwd`
-
-  M2_HOME=`dirname "$PRG"`/..
-
-  # make it fully qualified
-  M2_HOME=`cd "$M2_HOME" && pwd`
-
-  cd "$saveddir"
-  # echo Using m2 at $M2_HOME
-fi
-
-# For Cygwin, ensure paths are in UNIX format before anything is touched
-if $cygwin ; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME=`cygpath --unix "$M2_HOME"`
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
-fi
-
-# For Mingw, ensure paths are in UNIX format before anything is touched
-if $mingw ; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME="`(cd "$M2_HOME"; pwd)`"
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
-fi
-
-if [ -z "$JAVA_HOME" ]; then
-  javaExecutable="`which javac`"
-  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
-    # readlink(1) is not available as standard on Solaris 10.
-    readLink=`which readlink`
-    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
-      if $darwin ; then
-        javaHome="`dirname \"$javaExecutable\"`"
-        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
-      else
-        javaExecutable="`readlink -f \"$javaExecutable\"`"
-      fi
-      javaHome="`dirname \"$javaExecutable\"`"
-      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
-      JAVA_HOME="$javaHome"
-      export JAVA_HOME
-    fi
-  fi
-fi
-
-if [ -z "$JAVACMD" ] ; then
-  if [ -n "$JAVA_HOME"  ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
       # IBM's JDK on AIX uses strange locations for the executables
       JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
     else
       JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
     fi
   else
-    JAVACMD="`\\unset -f command; \\command -v java`"
-  fi
-fi
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
 
-if [ ! -x "$JAVACMD" ] ; then
-  echo "Error: JAVA_HOME is not defined correctly." >&2
-  echo "  We cannot execute $JAVACMD" >&2
-  exit 1
-fi
-
-if [ -z "$JAVA_HOME" ] ; then
-  echo "Warning: JAVA_HOME environment variable is not set."
-fi
-
-CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
-
-# traverses directory structure from process work directory to filesystem root
-# first directory with .mvn subdirectory is considered project base directory
-find_maven_basedir() {
-
-  if [ -z "$1" ]
-  then
-    echo "Path not specified to find_maven_basedir"
-    return 1
-  fi
-
-  basedir="$1"
-  wdir="$1"
-  while [ "$wdir" != '/' ] ; do
-    if [ -d "$wdir"/.mvn ] ; then
-      basedir=$wdir
-      break
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
     fi
-    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
-    if [ -d "${wdir}" ]; then
-      wdir=`cd "$wdir/.."; pwd`
-    fi
-    # end of workaround
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
   done
-  echo "${basedir}"
+  printf %x\\n $h
 }
 
-# concatenates all lines of a file
-concat_lines() {
-  if [ -f "$1" ]; then
-    echo "$(tr -s '\n' ' ' < "$1")"
-  fi
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
 }
 
-BASE_DIR=`find_maven_basedir "$(pwd)"`
-if [ -z "$BASE_DIR" ]; then
-  exit 1;
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
 fi
 
-##########################################################################################
-# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
-# This allows using the maven wrapper in projects that prohibit checking in binary data.
-##########################################################################################
-if [ -r "$BASE_DIR/.mvn/wrapper/maven-wrapper.jar" ]; then
-    if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Found .mvn/wrapper/maven-wrapper.jar"
-    fi
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
 else
-    if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
-    fi
-    if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
-    else
-      jarUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
-    fi
-    while IFS="=" read key value; do
-      case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
-      esac
-    done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
-    if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Downloading from: $jarUrl"
-    fi
-    wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
-    if $cygwin; then
-      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
-    fi
-
-    if command -v wget > /dev/null; then
-        if [ "$MVNW_VERBOSE" = true ]; then
-          echo "Found wget ... using wget"
-        fi
-        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            wget "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
-        else
-            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
-        fi
-    elif command -v curl > /dev/null; then
-        if [ "$MVNW_VERBOSE" = true ]; then
-          echo "Found curl ... using curl"
-        fi
-        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            curl -o "$wrapperJarPath" "$jarUrl" -f
-        else
-            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
-        fi
-
-    else
-        if [ "$MVNW_VERBOSE" = true ]; then
-          echo "Falling back to using Java to download"
-        fi
-        javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
-        # For Cygwin, switch paths to Windows format before running javac
-        if $cygwin; then
-          javaClass=`cygpath --path --windows "$javaClass"`
-        fi
-        if [ -e "$javaClass" ]; then
-            if [ ! -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
-                if [ "$MVNW_VERBOSE" = true ]; then
-                  echo " - Compiling MavenWrapperDownloader.java ..."
-                fi
-                # Compiling the Java class
-                ("$JAVA_HOME/bin/javac" "$javaClass")
-            fi
-            if [ -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
-                # Running the downloader
-                if [ "$MVNW_VERBOSE" = true ]; then
-                  echo " - Running MavenWrapperDownloader.java ..."
-                fi
-                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$MAVEN_PROJECTBASEDIR")
-            fi
-        fi
-    fi
-fi
-##########################################################################################
-# End of extension
-##########################################################################################
-
-export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
-if [ "$MVNW_VERBOSE" = true ]; then
-  echo $MAVEN_PROJECTBASEDIR
-fi
-MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
-
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME=`cygpath --path --windows "$M2_HOME"`
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
-    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
+  die "cannot create temp dir"
 fi
 
-# Provide a "standardized" way to retrieve the CLI args that will
-# work with both Windows and non-Windows executions.
-MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
-export MAVEN_CMD_LINE_ARGS
+mkdir -p -- "${MAVEN_HOME%/*}"
 
-WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
 
-exec "$JAVACMD" \
-  $MAVEN_OPTS \
-  $MAVEN_DEBUG_OPTS \
-  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
-  "-Dmaven.home=${M2_HOME}" \
-  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,3 +1,4 @@
+<# : batch portion
 @REM ----------------------------------------------------------------------------
 @REM Licensed to the Apache Software Foundation (ASF) under one
 @REM or more contributor license agreements.  See the NOTICE file
@@ -7,7 +8,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    https://www.apache.org/licenses/LICENSE-2.0
+@REM    http://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an
@@ -18,171 +19,171 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Maven Start Up Batch script
-@REM
-@REM Required ENV vars:
-@REM JAVA_HOME - location of a JDK home dir
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
 @REM
 @REM Optional ENV vars
-@REM M2_HOME - location of maven2's installed home dir
-@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
-@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
-@REM     e.g. to debug Maven itself, use
-@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
 @REM ----------------------------------------------------------------------------
 
-@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
-@echo off
-@REM set title of command window
-title %0
-@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
-@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
-
-@REM set %HOME% to equivalent of $HOME
-if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
-
-@REM Execute a user defined script before this one
-if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
-@REM check for pre script, once with legacy .bat ending and once with .cmd ending
-if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
-if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
-:skipRcPre
-
-@setlocal
-
-set ERROR_CODE=0
-
-@REM To isolate internal variables from possible post scripts, we use another setlocal
-@setlocal
-
-@REM ==== START VALIDATION ====
-if not "%JAVA_HOME%" == "" goto OkJHome
-
-echo.
-echo Error: JAVA_HOME not found in your environment. >&2
-echo Please set the JAVA_HOME variable in your environment to match the >&2
-echo location of your Java installation. >&2
-echo.
-goto error
-
-:OkJHome
-if exist "%JAVA_HOME%\bin\java.exe" goto init
-
-echo.
-echo Error: JAVA_HOME is set to an invalid directory. >&2
-echo JAVA_HOME = "%JAVA_HOME%" >&2
-echo Please set the JAVA_HOME variable in your environment to match the >&2
-echo location of your Java installation. >&2
-echo.
-goto error
-
-@REM ==== END VALIDATION ====
-
-:init
-
-@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
-@REM Fallback to current working directory if not found.
-
-set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
-IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
-
-set EXEC_DIR=%CD%
-set WDIR=%EXEC_DIR%
-:findBaseDir
-IF EXIST "%WDIR%"\.mvn goto baseDirFound
-cd ..
-IF "%WDIR%"=="%CD%" goto baseDirNotFound
-set WDIR=%CD%
-goto findBaseDir
-
-:baseDirFound
-set MAVEN_PROJECTBASEDIR=%WDIR%
-cd "%EXEC_DIR%"
-goto endDetectBaseDir
-
-:baseDirNotFound
-set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
-cd "%EXEC_DIR%"
-
-:endDetectBaseDir
-
-IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
-
-@setlocal EnableExtensions EnableDelayedExpansion
-for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
-@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
-
-:endReadAdditionalConfig
-
-SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
-set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
-set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
-
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
-
-FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
-    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
 )
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
 
-@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
-@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
-if exist %WRAPPER_JAR% (
-    if "%MVNW_VERBOSE%" == "true" (
-        echo Found %WRAPPER_JAR%
-    )
-) else (
-    if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
-    )
-    if "%MVNW_VERBOSE%" == "true" (
-        echo Couldn't find %WRAPPER_JAR%, downloading it ...
-        echo Downloading from: %DOWNLOAD_URL%
-    )
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
 
-    powershell -Command "&{"^
-		"$webclient = new-object System.Net.WebClient;"^
-		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
-		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
-		"}"^
-		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
-		"}"
-    if "%MVNW_VERBOSE%" == "true" (
-        echo Finished downloading %WRAPPER_JAR%
-    )
-)
-@REM End of extension
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
 
-@REM Provide a "standardized" way to retrieve the CLI args that will
-@REM work with both Windows and non-Windows executions.
-set MAVEN_CMD_LINE_ARGS=%*
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
 
-%MAVEN_JAVA_EXE% ^
-  %JVM_CONFIG_MAVEN_PROPS% ^
-  %MAVEN_OPTS% ^
-  %MAVEN_DEBUG_OPTS% ^
-  -classpath %WRAPPER_JAR% ^
-  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
-  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
-if ERRORLEVEL 1 goto error
-goto end
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
 
-:error
-set ERROR_CODE=1
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
 
-:end
-@endlocal & set ERROR_CODE=%ERROR_CODE%
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
 
-if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
-@REM check for post script, once with legacy .bat ending and once with .cmd ending
-if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
-if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
-:skipRcPost
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
 
-@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
-if "%MAVEN_BATCH_PAUSE%"=="on" pause
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 
-if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
 
-cmd /C exit /B %ERROR_CODE%
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.2</version>
+        <version>0.2.5</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <revision>0.1.0-SNAPSHOT</revision>
+        <revision>0.1.1-SNAPSHOT</revision>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request introduces several improvements to the project infrastructure and codebase. The main changes include enhancements to the Maven publishing workflow, improved documentation and code clarity in the i18n core classes through detailed Javadoc comments and usage examples, dependency and Maven wrapper updates, and the addition of Dependabot configuration for automated dependency management.

**CI/CD and Automation Improvements:**

* Enhanced the Maven publishing workflow (`.github/workflows/maven-publish.yml`) by adding strict version format validation, a new release job that creates Git tags and GitHub releases, and automatic patch version bumping after each release. This ensures consistent versioning and automates the release process. [[1]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL17-R32) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR61-R115)
* Added a Dependabot configuration file (`.github/dependabot.yml`) to enable daily automated dependency update checks for Maven dependencies.
* Updated Maven build workflow by removing the Maven cache configuration, possibly to address caching issues or simplify the workflow. (`.github/workflows/maven-build.yml`)

**Documentation and Code Quality Enhancements:**

* Added comprehensive Javadoc comments, including example usage, to key classes and methods in `microsphere-i18n-core` (such as `AbstractServiceMessageSource`, `AbstractResourceServiceMessageSource`, and `CompositeServiceMessageSource`). This improves maintainability and helps new contributors understand the codebase more easily. [[1]](diffhunk://#diff-a67440fdd96f916c753439823bad4712b3b6b8b69de04bcd5da9573f9456032cL21-R31) [[2]](diffhunk://#diff-9d346e443ea718db5ebccf0c30588fd0859af0722d93fffcdf40800e7d9dfba7L22-R32) [[3]](diffhunk://#diff-c6f52023708be21968bd1b016956a7570aa290918ff4ec7d3ce2ddf05ca8e7f2R26-R36) [[4]](diffhunk://#diff-a67440fdd96f916c753439823bad4712b3b6b8b69de04bcd5da9573f9456032cR51-R55) [[5]](diffhunk://#diff-9d346e443ea718db5ebccf0c30588fd0859af0722d93fffcdf40800e7d9dfba7R49-R58) [[6]](diffhunk://#diff-c6f52023708be21968bd1b016956a7570aa290918ff4ec7d3ce2ddf05ca8e7f2R51-R73) [[7]](diffhunk://#diff-a67440fdd96f916c753439823bad4712b3b6b8b69de04bcd5da9573f9456032cR132-R138) [[8]](diffhunk://#diff-a67440fdd96f916c753439823bad4712b3b6b8b69de04bcd5da9573f9456032cR150-R172) [[9]](diffhunk://#diff-a67440fdd96f916c753439823bad4712b3b6b8b69de04bcd5da9573f9456032cR182-R193) [[10]](diffhunk://#diff-a67440fdd96f916c753439823bad4712b3b6b8b69de04bcd5da9573f9456032cR215-R244) [[11]](diffhunk://#diff-9d346e443ea718db5ebccf0c30588fd0859af0722d93fffcdf40800e7d9dfba7R127-R166) [[12]](diffhunk://#diff-9d346e443ea718db5ebccf0c30588fd0859af0722d93fffcdf40800e7d9dfba7R179-R191) [[13]](diffhunk://#diff-9d346e443ea718db5ebccf0c30588fd0859af0722d93fffcdf40800e7d9dfba7R210-R215) [[14]](diffhunk://#diff-c6f52023708be21968bd1b016956a7570aa290918ff4ec7d3ce2ddf05ca8e7f2R123-R127)

**Dependency and Build Tool Updates:**

* Updated the Maven wrapper to use version 3.9.9 from an alternative mirror and switched to script-only distribution, which may improve build reliability and speed in some environments. (`.mvn/wrapper/maven-wrapper.properties`)
* Updated test dependencies in `microsphere-i18n-core/pom.xml` to use `junit-jupiter` (JUnit 5) and added `microsphere-spring-test` and `microsphere-logback` for improved testing and logging capabilities.

These changes collectively improve the project's automation, documentation, and maintainability.