### PR TITLE
Bump parent POM and microsphere-spring-cloud version to 0.1.8

### DIFF
--- a/microsphere-i18n-parent/pom.xml
+++ b/microsphere-i18n-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.7</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.8</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.7</version>
+        <version>0.1.8</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates the project to use the latest version of the `microsphere-spring-cloud` dependency. The main changes are version bumps in the parent POM files to ensure the project is using version `0.1.8`.

Dependency version updates:

* Updated the `microsphere-spring-cloud.version` property in `microsphere-i18n-parent/pom.xml` from `0.1.7` to `0.1.8`.
* Updated the parent POM version in `pom.xml` from `0.1.7` to `0.1.8`.