### PR TITLE
Bump parent POM and microsphere-spring-cloud version to 0.1.8

### DIFF
--- a/microsphere-i18n-parent/pom.xml
+++ b/microsphere-i18n-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.7</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.8</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.7</version>
+        <version>0.1.8</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates the Microsphere Spring Cloud dependency version across the project to ensure the latest features and fixes are used.

Dependency version updates:

* Updated the parent POM version in `pom.xml` from `0.1.7` to `0.1.8` to use the latest release of Microsphere Spring Cloud.
* Updated the `microsphere-spring-cloud.version` property in `microsphere-i18n-parent/pom.xml` from `0.1.7` to `0.1.8` for consistency with the parent POM.