### PR TITLE
Enhance CI workflows and update documentation for release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-- package-ecosystem: "maven" # See documentation for possible values
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -8,6 +8,9 @@
 
 name: Maven Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'dev-1.x' ]

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -119,8 +119,9 @@ jobs:
           prompt = (
               f"Generate concise release notes for version {current_tag}.\n\n"
               f"Commits since {prev_tag}:\n{commits}\n\n"
-              "Format the output as markdown with sections for New Features, Bug Fixes, "
-              "and Other Changes (only include sections that have relevant commits). "
+              "Format the output as markdown with sections if present for New Features, Bug Fixes, "
+              "Documentations, Dependency Updates, Test Improvements, Build and Workflow Enhancements "
+              "and Other Changes(excludes Full Changelog).\n\n"
               "Be concise and clear."
           )
 
@@ -153,20 +154,25 @@ jobs:
           if [ ! -f "$NOTES_FILE" ]; then
             printf "# Release Notes\n\n" > "$NOTES_FILE"
           fi
+          
+          FULL_CHANGELOG="**Full Changelog**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$PREV_TAG...$CURRENT_TAG"
+          
           printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
-
+          printf "%s" "$FULL_CHANGELOG" >> "$NOTES_FILE"
+          
           # Write the current release notes to a temp file for the Create Release step
-          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s\n\n" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s" "$FULL_CHANGELOG" >> /tmp/current-release-notes.md
 
           echo "Release notes generated and appended to $NOTES_FILE"
 
       - name: Create Release
         run: |
-          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
-            echo "Release v${{ inputs.revision }} already exists, skipping."
+          if gh release view "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release ${{ inputs.revision }} already exists, skipping."
           else
             gh release create ${{ inputs.revision }} \
-              --title "v${{ inputs.revision }}" \
+              --title "${{ inputs.revision }}" \
               --notes-file /tmp/current-release-notes.md \
               --latest
           fi

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,20 +14,22 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'The version to publish for Spring Cloud Hoxton+ and JDK 8+'
+        description: 'The version to publish for Spring Cloud Hoxton to 2021'
         required: true
         default: '${major}.${minor}.${patch}'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.revision }}
     steps:
       - name: Validate version format
         run: |
           if ! echo "${{ inputs.revision }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-          echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
-          exit 1
+            echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
+            exit 1
           fi
 
       - name: Checkout Source
@@ -59,12 +61,12 @@ jobs:
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
 
-
   release:
     runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: write
+      models: read
     steps:
       - name: Checkout Source
         uses: actions/checkout@v5
@@ -82,14 +84,90 @@ jobs:
             git push origin ${{ inputs.revision }}
           fi
 
+      - name: Generate Release Notes with Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_TAG="${{ inputs.revision }}"
+
+          # Find the previous tag (the one before the current tag)
+          PREV_TAG=$(git describe --tags --abbrev=0 --exclude="${CURRENT_TAG}" HEAD 2>/dev/null || echo "")
+
+          # Collect commits between the previous tag and HEAD
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline "${PREV_TAG}..HEAD" 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="$PREV_TAG"
+          else
+            COMMITS=$(git log --oneline -50 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="the beginning"
+          fi
+
+          # Export for Python (avoids shell-escaping issues with multiline content)
+          export CURRENT_TAG_DATA="$CURRENT_TAG"
+          export PREV_TAG_DATA="$SINCE_LABEL"
+          export COMMITS_DATA="$COMMITS"
+
+          # Call GitHub Copilot via GitHub Models API and capture the summary
+          SUMMARY=$(python3 << 'PYEOF'
+          import json, os, urllib.request, sys
+
+          current_tag = os.environ['CURRENT_TAG_DATA']
+          prev_tag    = os.environ['PREV_TAG_DATA']
+          commits     = os.environ['COMMITS_DATA']
+          token       = os.environ['GH_TOKEN']
+
+          prompt = (
+              f"Generate concise release notes for version {current_tag}.\n\n"
+              f"Commits since {prev_tag}:\n{commits}\n\n"
+              "Format the output as markdown with sections for New Features, Bug Fixes, "
+              "and Other Changes (only include sections that have relevant commits). "
+              "Be concise and clear."
+          )
+
+          payload = json.dumps({
+              "model": "gpt-4o",
+              "messages": [{"role": "user", "content": prompt}]
+          }).encode()
+
+          req = urllib.request.Request(
+              "https://models.inference.ai.azure.com/chat/completions",
+              data=payload,
+              headers={
+                  "Content-Type": "application/json",
+                  "Authorization": f"Bearer {token}"
+              }
+          )
+
+          try:
+              with urllib.request.urlopen(req) as resp:
+                  data = json.loads(resp.read())
+                  print(data["choices"][0]["message"]["content"])
+          except Exception as e:
+              print(f"Failed to generate summary via Copilot: {e}", file=sys.stderr)
+              print(f"_Release notes generation failed. Raw commits since {prev_tag}:_\n\n```\n{commits}\n```")
+          PYEOF
+          )
+
+          # Append the summary (with version header) to release-notes.md
+          NOTES_FILE="release-notes.md"
+          if [ ! -f "$NOTES_FILE" ]; then
+            printf "# Release Notes\n\n" > "$NOTES_FILE"
+          fi
+          printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
+
+          # Write the current release notes to a temp file for the Create Release step
+          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+
+          echo "Release notes generated and appended to $NOTES_FILE"
+
       - name: Create Release
         run: |
           if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
             echo "Release v${{ inputs.revision }} already exists, skipping."
           else
-            gh release create v${{ inputs.revision }} \
+            gh release create ${{ inputs.revision }} \
               --title "v${{ inputs.revision }}" \
-              --generate-notes \
+              --notes-file /tmp/current-release-notes.md \
               --latest
           fi
         env:
@@ -110,7 +188,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pom.xml
+          git add pom.xml release-notes.md
           git diff --cached --quiet && echo "No changes to commit" || \
             git commit -m "chore: bump version to next patch after publishing ${{ inputs.revision }}" && git push
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ project's pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.4              |
-| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.4              |
+| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.5              |
+| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.5              |
 
 Then add the specific modules you need:
 

--- a/microsphere-i18n-parent/pom.xml
+++ b/microsphere-i18n-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.10</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.11</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request introduces several improvements to the CI/CD workflow and release automation for the project, along with minor dependency and documentation updates. The main enhancements include automated generation of release notes using GitHub Copilot, improved workflow permissions, and version bumps in documentation and dependencies.

**CI/CD Workflow and Release Automation Improvements:**

* Added a step in the `maven-publish.yml` workflow to automatically generate concise, markdown-formatted release notes using GitHub Copilot and the Models API, based on commit history between tags. The generated notes are appended to `release-notes.md` and used as the body for GitHub releases.
* Updated the release creation step to use the generated release notes instead of auto-generated notes, and ensured the release notes file is committed back to the repository after publishing. [[1]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR87-R176) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL113-R197)
* Added explicit `permissions` blocks to both `maven-build.yml` and `maven-publish.yml` workflows to follow GitHub Actions best practices and enable required access for new features. [[1]](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2R11-R13) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL17-R25) [[3]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL62-R69)

**Dependency and Documentation Updates:**

* Bumped the version of `microsphere-spring-cloud` in `pom.xml` and `microsphere-i18n-parent/pom.xml` from `0.1.10` to `0.1.11`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9) [[2]](diffhunk://#diff-ac3ea6d8f650966a48b4fee69ec6ae0d2db64fa8d9e22b12549700dc7a12fd26L23-R23)
* Updated the latest version numbers in the `README.md` to reflect the new releases (`0.2.5` and `0.1.5`).