### PR TITLE
Standardize CI workflows and update project dependencies

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -28,14 +28,15 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v5
 
-      - name: Setup JDK ${{ matrix.Java }}
+      - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Build with Maven
-        run: ./mvnw
+        run: mvn
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -42,7 +42,7 @@ jobs:
           --file pom.xml
           -Drevision=0.0.1-SNAPSHOT
           test
-          --activate-profiles test,coverage,testcontainers,${{ matrix.maven-profile-spring-cloud }}
+          --activate-profiles test,coverage,${{ matrix.maven-profile-spring-cloud }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,13 +40,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          cache: maven
 
       - name: Publish package
-        run: mvn
+        run: ./mvnw
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ project's pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.5              |
-| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.5              |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.6              |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.6              |
 
 Then add the specific modules you need:
 

--- a/microsphere-i18n-parent/pom.xml
+++ b/microsphere-i18n-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.11</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.12</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.11</version>
+        <version>0.1.12</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates the project to use newer dependency versions, improves the Maven build and publish workflows, and updates documentation to reflect these changes. The main focus is on aligning with the latest versions and streamlining CI/CD processes.

**Dependency and Version Updates:**
* Updated the parent POM version in `pom.xml` and the `microsphere-spring-cloud.version` property in `microsphere-i18n-parent/pom.xml` from `0.1.11` to `0.1.12` to use the latest dependencies. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9) [[2]](diffhunk://#diff-ac3ea6d8f650966a48b4fee69ec6ae0d2db64fa8d9e22b12549700dc7a12fd26L23-R23)

**Build and CI/CD Workflow Improvements:**
* In `.github/workflows/maven-build.yml`, switched from `./mvnw` to `mvn` for builds, enabled Maven caching, and removed the `testcontainers` profile from the activated profiles list.
* In `.github/workflows/maven-publish.yml`, switched from `mvn` to `./mvnw` for publishing and removed unused Maven server credentials and cache configuration.

**Documentation Updates:**
* Updated the version table in `README.md` to reflect new branch names and latest released versions (`main`/`0.2.6`, `1.x`/`0.1.6`).