### PR TITLE
Add Maven credentials to CI workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
 
       - name: Publish package
         run: ./mvnw


### PR DESCRIPTION
Provide Maven Central credentials in the GitHub Actions workflow by adding server-id (ossrh) and mapping server-username/server-password to MAVEN_USERNAME/MAVEN_PASSWORD. These values (intended to come from repository secrets) allow the subsequent Publish package step (./mvnw) to authenticate when deploying artifacts to OSSRH/Maven Central.