### PR TITLE
Bump versions in README and parent POM to 0.2.10 and 0.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Choose the version that matches your Spring Cloud generation:
 
 | **Branch** | **Compatible Spring Cloud** | **Latest Version** |
 |------------|-----------------------------|--------------------|
-| **main**   | 2022.0.x – 2025.0.x         | `0.2.9`            |
-| **1.x**    | Hoxton – 2021.0.x           | `0.1.9`            |
+| **main**   | 2022.0.x – 2025.0.x         | `0.2.10`           |
+| **1.x**    | Hoxton – 2021.0.x           | `0.1.10`           |
 
 ### Spring Applications
 

--- a/microsphere-i18n-parent/pom.xml
+++ b/microsphere-i18n-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.14</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.15</microsphere-spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates version numbers across the project to prepare for a new release. The changes ensure that the documentation and dependency management reflect the latest versions.

Version updates:

* Updated the latest version numbers for both the `main` and `1.x` branches in the `README.md` to `0.2.10` and `0.1.10` respectively.
* Bumped the `microsphere-spring-cloud.version` property in `microsphere-i18n-parent/pom.xml` from `0.1.14` to `0.1.15`.
* Updated the parent POM version in the root `pom.xml` from `0.1.14` to `0.1.15`.